### PR TITLE
Migration to Tomcat 8 / Java 8.

### DIFF
--- a/Applets/VIP-Cowork-Applet/pom.xml
+++ b/Applets/VIP-Cowork-Applet/pom.xml
@@ -37,7 +37,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
   <modelVersion>4.0.0</modelVersion>
   <groupId>fr.insalyon.creatis.vip</groupId>
   <artifactId>VIP-Cowork-Applet</artifactId>
-  <version>1.13</version>
+  <version>1.15</version>
   <name>VIP-Cowork-Applet</name>
   <url>http://maven.apache.org</url>
   <properties>
@@ -122,8 +122,8 @@ knowledge of the CeCILL-B license and that you accept its terms.
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.0.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/Applets/VIP-DataManager-Applet/pom.xml
+++ b/Applets/VIP-DataManager-Applet/pom.xml
@@ -38,7 +38,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
     <groupId>fr.insalyon.creatis</groupId>
     <artifactId>vip-datamanager-applet</artifactId>
     <packaging>jar</packaging>
-    <version>1.13</version>
+    <version>1.15</version>
 
     <name>VIP-DataManager-Applet</name>
 
@@ -82,7 +82,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
         <dependency>
             <groupId>sun.jdk</groupId>
             <artifactId>plugin</artifactId>
-            <version>1.7.0</version>
+            <version>1.8.0</version>
             <scope>system</scope>
             <systemPath>${java.home}/lib/plugin.jar</systemPath>
         </dependency>
@@ -94,6 +94,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.2-beta-5</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -138,6 +139,15 @@ knowledge of the CeCILL-B license and that you accept its terms.
                     <alias>${applet.alias}</alias>
                     <storepass>${applet.storepass}</storepass>
                     <keypass>${applet.keypass}</keypass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.0.2</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/Applets/VIP-DataManager-Applet/src/main/java/fr/insalyon/creatis/vip/datamanager/applet/upload/UploadFiles.java
+++ b/Applets/VIP-DataManager-Applet/src/main/java/fr/insalyon/creatis/vip/datamanager/applet/upload/UploadFiles.java
@@ -448,6 +448,6 @@ private void jButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST
 
     public void complete() {
         JSObject win = JSObject.getWindow(this);
-        win.call("dataManagerUploadComplete", new String[]{business.getResult()});
+        win.eval("dataManagerUploadComplete('"+business.getResult()+"')");
     }
 }

--- a/Applets/VIP-Gatelab-Applet/pom.xml
+++ b/Applets/VIP-Gatelab-Applet/pom.xml
@@ -38,7 +38,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
     <groupId>fr.insalyon.creatis</groupId>
     <artifactId>vip-gatelab-applet</artifactId>
     <packaging>jar</packaging>
-    <version>1.13</version>
+    <version>1.15</version>
     <name>VIP-Gatelab-Applet</name>
     <dependencies>
 
@@ -52,13 +52,13 @@ knowledge of the CeCILL-B license and that you accept its terms.
         <dependency>
             <groupId>fr.insalyon.creatis</groupId>
             <artifactId>vip-datamanager-applet</artifactId>
-            <version>1.9</version>
+            <version>1.15</version>
         </dependency>
 
         <dependency>
             <groupId>sun.jdk</groupId>
             <artifactId>plugin</artifactId>
-            <version>1.7.0</version>
+            <version>1.8.0</version>
             <scope>system</scope>
             <systemPath>${java.home}/lib/plugin.jar</systemPath>
         </dependency>
@@ -122,8 +122,8 @@ knowledge of the CeCILL-B license and that you accept its terms.
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.0.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/Portal/pom.xml
+++ b/Portal/pom.xml
@@ -37,30 +37,30 @@ knowledge of the CeCILL-B license and that you accept its terms.
     <groupId>fr.insalyon.creatis</groupId>
     <artifactId>vip</artifactId>
     <packaging>pom</packaging>
-    <version>1.14</version>
+    <version>1.15</version>
     <name>VIP</name>
     
     <properties>
-        <vip.core.version>1.14</vip.core.version>
-        <vip.portal.version>1.14</vip.portal.version>
-        <vip.docs.version>1.6</vip.docs.version>
-        <vip.application.version>1.12</vip.application.version>
-        <vip.datamanager.version>1.12</vip.datamanager.version>
-        <vip.datamanager-applet.version>1.13</vip.datamanager-applet.version>
-        <vip.gatelab.version>1.9</vip.gatelab.version>
-        <vip.gatelab-applet.version>1.13</vip.gatelab-applet.version>
+        <vip.core.version>1.15</vip.core.version>
+        <vip.portal.version>1.15</vip.portal.version>
+        <vip.docs.version>1.15</vip.docs.version>
+        <vip.application.version>1.15</vip.application.version>
+        <vip.datamanager.version>1.15</vip.datamanager.version>
+        <vip.datamanager-applet.version>1.15</vip.datamanager-applet.version>
+        <vip.gatelab.version>1.15</vip.gatelab.version>
+        <vip.gatelab-applet.version>1.15</vip.gatelab-applet.version>
         <vip.simulation-gui.version>0.4.1</vip.simulation-gui.version>
         <vip.models.version>0.9.1</vip.models.version>
         <vip.simulated-data.version>1.3.1</vip.simulated-data.version>
-        <vip.social.version>1.12</vip.social.version>
+        <vip.social.version>1.15</vip.social.version>
         <vip.provenance.version>0.1.2</vip.provenance.version>
         <vip.cowork.version>0.1</vip.cowork.version>
-        <vip.cowork-applet.version>1.13</vip.cowork-applet.version>
+        <vip.cowork-applet.version>1.15</vip.cowork-applet.version>
         <vip.cardiac.version>0.9.4</vip.cardiac.version>
         <vip.physical-properties.version>0.1</vip.physical-properties.version>
         <vip.query.version>1.7</vip.query.version>
-        <vip.application-importer.version>1.14</vip.application-importer.version>
-        <vip.api.version>1.14</vip.api.version>
+        <vip.application-importer.version>1.15</vip.application-importer.version>
+        <vip.api.version>1.15</vip.api.version>
     </properties>
     
     <description>VIP</description>

--- a/Portal/pom.xml
+++ b/Portal/pom.xml
@@ -152,8 +152,8 @@ knowledge of the CeCILL-B license and that you accept its terms.
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/Portal/vip-api/nb-configuration.xml
+++ b/Portal/vip-api/nb-configuration.xml
@@ -46,6 +46,6 @@ You can copy and paste the single properties, into the pom.xml file and the IDE 
 That way multiple projects can share the same settings (useful for formatting rules for example).
 Any value defined here will override the pom.xml file value but is only applicable to the current project.
 -->
-        <netbeans.hint.jdkPlatform>JDK_1.7__sun_</netbeans.hint.jdkPlatform>
+        <netbeans.hint.jdkPlatform>JDK_1.8</netbeans.hint.jdkPlatform>
     </properties>
 </project-shared-configuration>

--- a/Portal/vip-api/pom.xml
+++ b/Portal/vip-api/pom.xml
@@ -37,7 +37,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
     <parent>
         <groupId>fr.insalyon.creatis</groupId>
         <artifactId>vip</artifactId>
-        <version>1.14</version>
+        <version>1.15</version>
     </parent>
     <groupId>fr.insalyon.creatis</groupId>
     <artifactId>vip-api</artifactId>
@@ -51,8 +51,8 @@ knowledge of the CeCILL-B license and that you accept its terms.
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/Portal/vip-application-importer/pom.xml
+++ b/Portal/vip-application-importer/pom.xml
@@ -37,7 +37,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
     <parent>
         <artifactId>vip</artifactId>
         <groupId>fr.insalyon.creatis</groupId>
-        <version>1.14</version>
+        <version>1.15</version>
     </parent>
 
     <groupId>fr.insalyon.creatis</groupId>
@@ -114,8 +114,8 @@ knowledge of the CeCILL-B license and that you accept its terms.
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.5.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/Portal/vip-application/pom.xml
+++ b/Portal/vip-application/pom.xml
@@ -38,7 +38,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
     <parent>
         <groupId>fr.insalyon.creatis</groupId>
         <artifactId>vip</artifactId>
-        <version>1.14</version>
+        <version>1.15</version>
         <relativePath>..</relativePath>
     </parent>
     
@@ -153,6 +153,12 @@ knowledge of the CeCILL-B license and that you accept its terms.
 	<artifactId>jsoup</artifactId>
 	<version>1.7.2</version>
      </dependency>
+     
+        <dependency>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+            <version>1.4.01</version>
+        </dependency>
 
     </dependencies>
     <build>
@@ -161,8 +167,8 @@ knowledge of the CeCILL-B license and that you accept its terms.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/Portal/vip-core/pom.xml
+++ b/Portal/vip-core/pom.xml
@@ -89,8 +89,8 @@ knowledge of the CeCILL-B license and that you accept its terms.
 
         <dependency>
             <groupId>bouncycastle</groupId>
-            <artifactId>bcprov-jdk16</artifactId>
-            <version>1.41</version>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>152</version>
         </dependency>
                 
         <dependency>

--- a/Portal/vip-core/pom.xml
+++ b/Portal/vip-core/pom.xml
@@ -37,7 +37,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
     <parent>
         <groupId>fr.insalyon.creatis</groupId>
         <artifactId>vip</artifactId>
-        <version>1.14</version>
+        <version>1.15</version>
         <relativePath>..</relativePath>
     </parent>
     <groupId>fr.insalyon.creatis</groupId>
@@ -92,7 +92,13 @@ knowledge of the CeCILL-B license and that you accept its terms.
             <artifactId>bcprov-jdk15on</artifactId>
             <version>152</version>
         </dependency>
-                
+              
+        <dependency>
+            <groupId>bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>152</version>
+        </dependency>
+          
         <dependency>
             <groupId>fr.insalyon.creatis</groupId>
             <artifactId>grida-client</artifactId>
@@ -194,8 +200,8 @@ knowledge of the CeCILL-B license and that you accept its terms.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/client/view/CoreConstants.java
+++ b/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/client/view/CoreConstants.java
@@ -41,7 +41,7 @@ import java.util.List;
  */
 public class CoreConstants implements IsSerializable {
 
-    public static final String VERSION = "v1.14";
+    public static final String VERSION = "v1.15";
     // Configuration Labels
     public static final String VO_BIOMED = "biomed";
     public static final String VO_NEUGRID = "vo.neugrid.eu";

--- a/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/proxy/ProxyClient.java
+++ b/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/proxy/ProxyClient.java
@@ -43,16 +43,19 @@ import java.security.cert.*;
 import java.util.*;
 import javax.net.ssl.*;
 import javax.security.auth.login.FailedLoginException;
+import javax.security.auth.x500.X500Principal;
 import org.apache.log4j.Logger;
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.asn1.DERObject;
 import org.bouncycastle.asn1.DEROutputStream;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
-import org.bouncycastle.asn1.x509.X509Name;
-import org.bouncycastle.jce.PKCS10CertificationRequest;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.bouncycastle.util.encoders.Base64;
 import org.bouncycastle.asn1.ASN1Primitive;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
 
 /**
  *
@@ -95,14 +98,15 @@ public class ProxyClient {
 
             String proxyFileName = Server.getInstance().getServerProxy();
             if (new File(proxyFileName).exists()) {
-
-                FileInputStream is = new FileInputStream(proxyFileName);
+                FileInputStream fis = new FileInputStream(proxyFileName);
                 CertificateFactory cf = CertificateFactory.getInstance("X.509");
                 boolean valid = true;
                 Date endDate = null;
-
-                while (is.available() > 0) {
-                    X509Certificate certificate = (X509Certificate) cf.generateCertificate(is);
+          
+                //Parsing the certificate while (fis.available() > 0) gives a "CertificateParsingException: signed overrun"; the same code (with the while loop) works perfectly fine in a independent JavaTest class
+                //while (fis.available() > 0) {
+                    X509Certificate certificate = (X509Certificate) cf.generateCertificate(fis);
+                    System.out.println(certificate.toString());
                     Calendar currentDate = Calendar.getInstance();
                     currentDate.setTime(new Date());
                     currentDate.add(Calendar.HOUR, Server.getInstance().getMyProxyMinHours());
@@ -115,9 +119,9 @@ public class ProxyClient {
                         }
                     } catch (Exception ex1) {
                         valid = false;
-                        break;
+                        //break;
                     }
-                }
+                //}
                 if (valid) {
                     logger.info("Server proxy still valid until: " + endDate);
                     return new Proxy(proxyFileName, endDate);
@@ -261,14 +265,11 @@ public class ProxyClient {
         KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("RSA");
         keyPair = keyGenerator.generateKeyPair();
 
-        PKCS10CertificationRequest cert = new PKCS10CertificationRequest(
-                "MD5WITHRSA",
-                new X509Name("CN=irrelevant"),
-                keyPair.getPublic(),
-                null,
-                keyPair.getPrivate(),
-                "BC");
-
+        X500Principal subject = new X500Principal ("CN=irrelevant");
+        ContentSigner signGen = new JcaContentSignerBuilder("SHA1withRSA").build(keyPair.getPrivate());
+        PKCS10CertificationRequestBuilder builder = new JcaPKCS10CertificationRequestBuilder(subject, keyPair.getPublic());
+        PKCS10CertificationRequest cert = builder.build(signGen);
+       
         socketOut.write(cert.getEncoded());
         socketOut.write(0x00);
         socketOut.flush();
@@ -355,10 +356,6 @@ public class ProxyClient {
         ByteArrayInputStream inStream = new ByteArrayInputStream(key.getEncoded());
         ASN1InputStream derInputStream = new ASN1InputStream(inStream);
         ASN1Primitive keyInfo = derInputStream.readObject();
-        /*
-        PrivateKeyInfo pkey = new PrivateKeyInfo((ASN1Sequence) keyInfo);
-        ASN1Primitive derKey = pkey.getPrivateKey();
-        */
         PrivateKeyInfo pki;
         pki = PrivateKeyInfo.getInstance(keyInfo);
         ASN1Primitive innerType = pki.parsePrivateKey().toASN1Primitive();

--- a/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/proxy/ProxyClient.java
+++ b/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/proxy/ProxyClient.java
@@ -52,6 +52,7 @@ import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.asn1.x509.X509Name;
 import org.bouncycastle.jce.PKCS10CertificationRequest;
 import org.bouncycastle.util.encoders.Base64;
+import org.bouncycastle.asn1.ASN1Primitive;
 
 /**
  *
@@ -353,12 +354,19 @@ public class ProxyClient {
         out.println("-----BEGIN RSA PRIVATE KEY-----");
         ByteArrayInputStream inStream = new ByteArrayInputStream(key.getEncoded());
         ASN1InputStream derInputStream = new ASN1InputStream(inStream);
-        DERObject keyInfo = derInputStream.readObject();
+        ASN1Primitive keyInfo = derInputStream.readObject();
+        /*
         PrivateKeyInfo pkey = new PrivateKeyInfo((ASN1Sequence) keyInfo);
-        DERObject derKey = pkey.getPrivateKey();
+        ASN1Primitive derKey = pkey.getPrivateKey();
+        */
+        PrivateKeyInfo pki;
+        pki = PrivateKeyInfo.getInstance(keyInfo);
+        ASN1Primitive innerType = pki.parsePrivateKey().toASN1Primitive();
+        // build and return the actual key
+        ASN1Sequence privKey  = (ASN1Sequence)innerType;
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         DEROutputStream der = new DEROutputStream(bout);
-        der.writeObject(derKey);
+        der.writeObject(privKey);
         printB64(bout.toByteArray(), out);
         out.println("-----END RSA PRIVATE KEY-----");
     }

--- a/Portal/vip-datamanagement/pom.xml
+++ b/Portal/vip-datamanagement/pom.xml
@@ -37,7 +37,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
     <parent>
         <groupId>fr.insalyon.creatis</groupId>
         <artifactId>vip</artifactId>
-        <version>1.14</version>
+        <version>1.15</version>
         <relativePath>..</relativePath>
     </parent>
     <groupId>fr.insalyon.creatis</groupId>
@@ -74,8 +74,8 @@ knowledge of the CeCILL-B license and that you accept its terms.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/Portal/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/client/view/common/AppletHTMLPane.java
+++ b/Portal/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/client/view/common/AppletHTMLPane.java
@@ -64,6 +64,7 @@ public class AppletHTMLPane extends HTMLPane {
                 + "<param name=\"path\" value=\"" + path + "\"/>"
                 + "<param name=\"unzip\" value=\"" + unzip + "\"/>"
                 + "<param name=\"pool\" value=\"" + usePool + "\"/>"
+                + "<param name=\"permissions\" value=\"all-permissions\" />"     
                 + "</applet>"
                 + "</body>"
                 + "</html>");

--- a/Portal/vip-docs/pom.xml
+++ b/Portal/vip-docs/pom.xml
@@ -37,7 +37,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
     <parent>
         <groupId>fr.insalyon.creatis</groupId>
         <artifactId>vip</artifactId>
-        <version>1.14</version>
+        <version>1.15</version>
         <relativePath>..</relativePath>
     </parent>
     <groupId>fr.insalyon.creatis</groupId>
@@ -68,8 +68,8 @@ knowledge of the CeCILL-B license and that you accept its terms.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/Portal/vip-gatelab/pom.xml
+++ b/Portal/vip-gatelab/pom.xml
@@ -37,7 +37,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
     <parent>
         <groupId>fr.insalyon.creatis</groupId>
         <artifactId>vip</artifactId>
-        <version>1.14</version>
+        <version>1.15</version>
         <relativePath>..</relativePath>
     </parent>
     <groupId>fr.insalyon.creatis</groupId>
@@ -82,8 +82,8 @@ knowledge of the CeCILL-B license and that you accept its terms.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/Portal/vip-portal/pom.xml
+++ b/Portal/vip-portal/pom.xml
@@ -38,7 +38,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
     <parent>
         <groupId>fr.insalyon.creatis</groupId>
         <artifactId>vip</artifactId>
-        <version>1.14</version>
+        <version>1.15</version>
         <relativePath>..</relativePath>
     </parent>
     <groupId>fr.insalyon.creatis</groupId>
@@ -89,6 +89,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
             <groupId>fr.insalyon.creatis</groupId>
             <artifactId>vip-datamanager-applet</artifactId>
             <version>${vip.datamanager-applet.version}</version>
+            <classifier>jar-with-dependencies</classifier>
         </dependency>
 
         <dependency>
@@ -107,6 +108,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
             <groupId>fr.insalyon.creatis</groupId>
             <artifactId>vip-gatelab-applet</artifactId>
             <version>${vip.gatelab-applet.version}</version>
+            <classifier>jar-with-dependencies</classifier>
         </dependency>
         <dependency>
             <groupId>fr.insalyon.creatis.vip</groupId>
@@ -167,13 +169,12 @@ knowledge of the CeCILL-B license and that you accept its terms.
              <artifactId>vip-query</artifactId>
             <version>${vip.query.version}</version>
         </dependency>
-        
         <dependency>
              <groupId>fr.insalyon.creatis</groupId>
              <artifactId>vip-api</artifactId>
-            <version>${vip.api.version}</version>
+             <version>${vip.api.version}</version>
         </dependency>
-
+   
         <!-- END VIP MODULES -->
         <dependency>
             <groupId>org.glassfish.metro</groupId>
@@ -189,8 +190,8 @@ knowledge of the CeCILL-B license and that you accept its terms.
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             
@@ -249,6 +250,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
                                     <groupId>fr.insalyon.creatis</groupId>
                                     <artifactId>vip-datamanager-applet</artifactId>
                                     <overWrite>true</overWrite>
+                                    <classifier>jar-with-dependencies</classifier>
                                     <destFileName>vip-datamanager-applet.jar</destFileName>
                                 </artifactItem>
                                 
@@ -256,6 +258,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
                                     <groupId>fr.insalyon.creatis</groupId>
                                     <artifactId>vip-gatelab-applet</artifactId>
                                     <overWrite>true</overWrite>
+                                    <classifier>jar-with-dependencies</classifier>
                                     <destFileName>vip-gatelab-applet.jar</destFileName>
                                 </artifactItem>
                                 <artifactItem>

--- a/Portal/vip-portal/src/main/webapp/WEB-INF/sun-jaxws.xml
+++ b/Portal/vip-portal/src/main/webapp/WEB-INF/sun-jaxws.xml
@@ -31,7 +31,7 @@ The fact that you are presently reading this means that you have had
 knowledge of the CeCILL-B license and that you accept its terms.
 
 -->
-
 <endpoints version="2.0" xmlns="http://java.sun.com/xml/ns/jax-ws/ri/runtime">
   <endpoint implementation="fr.insalyon.creatis.vip.api.soap.PAF" name="api" url-pattern="/api"/>
+  <endpoint implementation="fr.insalyon.creatis.vip.portal.api" name="api" url-pattern="/api"/>
 </endpoints>

--- a/Portal/vip-portal/src/main/webapp/WEB-INF/web.xml
+++ b/Portal/vip-portal/src/main/webapp/WEB-INF/web.xml
@@ -31,7 +31,6 @@ The fact that you are presently reading this means that you have had
 knowledge of the CeCILL-B license and that you accept its terms.
 
 -->
-
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
     <display-name>VIP</display-name>
     <!-- Core Module -->

--- a/Portal/vip-social/pom.xml
+++ b/Portal/vip-social/pom.xml
@@ -38,7 +38,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
     <parent>
         <groupId>fr.insalyon.creatis</groupId>
         <artifactId>vip</artifactId>
-        <version>1.14</version>
+        <version>1.15</version>
         <relativePath>..</relativePath>
     </parent>
     
@@ -72,8 +72,8 @@ knowledge of the CeCILL-B license and that you accept its terms.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Attention, Java source and target change from 1.7 to 1.8.
The new bcprov-jdk15on dependency may have to be manually installed. It can be downloaded at this address: https://www.bouncycastle.org/download/bcprov-jdk15on-152.jar