### PR TITLE
Updates in authentication methods

### DIFF
--- a/Portal/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/monitor/SimulationsTab.java
+++ b/Portal/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/monitor/SimulationsTab.java
@@ -82,7 +82,7 @@ public class SimulationsTab extends Tab {
 
     public SimulationsTab() {
 
-        this.setTitle(Canvas.imgHTML(ApplicationConstants.ICON_MONITOR) + " Simulations");
+        this.setTitle(Canvas.imgHTML(ApplicationConstants.ICON_MONITOR) + " Executions");
         this.setID(ApplicationConstants.TAB_MONITOR);
         this.setCanClose(true);
         this.setAttribute("paneMargin", 0);

--- a/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/client/rpc/ConfigurationService.java
+++ b/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/client/rpc/ConfigurationService.java
@@ -74,8 +74,6 @@ public interface ConfigurationService extends RemoteService {
 
     public User signin(String email, String password) throws CoreException;
 
-    public User signin(String ticket) throws CoreException;
-
     public void signout() throws CoreException;
 
     public User activate(String code) throws CoreException;

--- a/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/client/rpc/ConfigurationServiceAsync.java
+++ b/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/client/rpc/ConfigurationServiceAsync.java
@@ -58,8 +58,6 @@ public interface ConfigurationServiceAsync {
 
     public void signin(String email, String password, AsyncCallback<User> asyncCallback);
 
-    public void signin(String ticket, AsyncCallback<User> asyncCallback);
-
     public void signout(AsyncCallback<Void> asyncCallback);
 
     public void activate(String code, AsyncCallback<User> asyncCallback);

--- a/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/client/view/CoreConstants.java
+++ b/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/client/view/CoreConstants.java
@@ -52,7 +52,6 @@ public class CoreConstants implements IsSerializable {
     public static final String LAB_ADMIN_INSTITUTION = "admin.institution";
     public static final String LAB_ADMIN_PHONE = "admin.phone";
     public static final String LAB_ADMIN_PASS = "admin.pass";
-    public static final String LAB_SAML_ACCOUNT_TYPE = "saml.accounttype";
     public static final String LAB_CAS_URL = "cas.url";
     public static final String LAB_MYPROXY_HOST = "myproxy.host";
     public static final String LAB_MYPROXY_PORT = "myproxy.port";

--- a/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/client/view/CoreConstants.java
+++ b/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/client/view/CoreConstants.java
@@ -173,7 +173,8 @@ public class CoreConstants implements IsSerializable {
     public static final String APPLET_GATELAB_CLASSES = "appletGatelab.classes";
     public static final String APPLET_GATELABTEST_CLASSES = "appletGatelabTest.classes";
     public static final String UNDESIRED_MAIL_DOMAINS = "emails.prohibitDomainsList";
-    public static final String SAML_TRUSTED_CERTIFICATE = "saml.trusted.certificates";
+    public static final String SAML_TRUSTED_CERTIFICATE = "saml.trustedcertificate";
+    public static final String SAML_ACCOUNT_TYPE = "saml.accounttype";
     public static String MOZILLA_PERSONA_VALIDATION_URL = "mozilla.persona.validation.url";
     //query
     public static String TreeQuery = "query.classes";

--- a/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/auth/AbstractAuthenticationService.java
+++ b/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/auth/AbstractAuthenticationService.java
@@ -41,6 +41,7 @@ import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Date;
+import java.util.List;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 import javax.servlet.ServletException;
@@ -58,8 +59,10 @@ public abstract class AbstractAuthenticationService extends HttpServlet {
 
     private static Logger logger = Logger.getLogger(AbstractAuthenticationService.class);
 
-    protected abstract String getEmailIfValidRequest(HttpServletRequest request) throws BusinessException;
+    protected abstract void checkValidRequest(HttpServletRequest request) throws BusinessException;
 
+    protected abstract String getEmail() throws BusinessException;
+    
     public abstract String getDefaultAccountType();
 
     @Override
@@ -85,8 +88,9 @@ public abstract class AbstractAuthenticationService extends HttpServlet {
     private void processRequest(HttpServletRequest request, HttpServletResponse response) throws BusinessException {
         logger.info("Third-party authentication request.");
         String email = null;
-        try {
-            email = getEmailIfValidRequest(request);
+        try { 
+            checkValidRequest(request);
+            email = getEmail();
         } catch (BusinessException ex) {
             logger.info(ex.getMessage());
             authFailedResponse(request, response);

--- a/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/auth/AbstractAuthenticationService.java
+++ b/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/auth/AbstractAuthenticationService.java
@@ -113,7 +113,6 @@ public abstract class AbstractAuthenticationService extends HttpServlet {
     private void authSuccessResponse(HttpServletRequest request, HttpServletResponse response, String email) throws BusinessException {
         //   try {
         ConfigurationBusiness cb = new ConfigurationBusiness();
-        String message = "";
         String accountType = getDefaultAccountType();
         User user = cb.getOrCreateUser(email, accountType);
         //third-party authentication services will *not* be trusted to let admins in

--- a/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/auth/SamlAuthenticationService.java
+++ b/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/auth/SamlAuthenticationService.java
@@ -127,7 +127,7 @@ public class SamlAuthenticationService extends AbstractAuthenticationService {
 
     @Override
     public String getDefaultAccountType() {
-        return Server.getInstance().getSAMLAccountType(issuer);
+        return Server.getInstance().getSAMLAccountType(issuer.getValue());
     }
 
     @Override

--- a/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/auth/SamlAuthenticationService.java
+++ b/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/auth/SamlAuthenticationService.java
@@ -31,13 +31,27 @@
  */
 package fr.insalyon.creatis.vip.core.server.auth;
 
-import fr.insalyon.creatis.vip.core.client.view.CoreException;
 import fr.insalyon.creatis.vip.core.server.business.BusinessException;
 import fr.insalyon.creatis.vip.core.server.business.SamlTokenValidator;
 import fr.insalyon.creatis.vip.core.server.business.Server;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.List;
+import java.util.logging.Level;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.log4j.Logger;
-import org.opensaml.saml2.core.impl.AssertionImpl;
+import org.opensaml.saml2.core.Assertion;
+import org.opensaml.saml2.core.Issuer;
+import org.opensaml.saml2.core.Response;
+import org.opensaml.xml.ConfigurationException;
+import org.opensaml.xml.io.UnmarshallingException;
+import org.opensaml.xml.parse.XMLParserException;
+import org.opensaml.xml.validation.ValidationException;
 
 /**
  *
@@ -46,9 +60,11 @@ import org.opensaml.saml2.core.impl.AssertionImpl;
 public class SamlAuthenticationService extends AbstractAuthenticationService {
 
     private static final Logger logger = Logger.getLogger(SamlAuthenticationService.class);
+    private Assertion assertion;
+    private Issuer issuer;
 
     @Override
-    protected String getEmailIfValidRequest(HttpServletRequest request) throws BusinessException {
+    protected void checkValidRequest(HttpServletRequest request) throws BusinessException {
         logger.info("SAML authentication request");
 
         String token = request.getParameter("_saml_token");
@@ -56,25 +72,67 @@ public class SamlAuthenticationService extends AbstractAuthenticationService {
             throw new BusinessException("SAML token is null");
         }
 
-        String email;
+        // Get the SAML assertion in XML form
+        // SAML assertion might be encoded in base64 (happens in FLI)
+        byte[] xmlAssertion = token.getBytes();
+        if (Base64.isBase64(xmlAssertion)) {
+            xmlAssertion = Base64.decodeBase64(xmlAssertion);
+        }
+
+        // Get an Assertion object from XML assertion
+        assertion = null;
         try {
-            AssertionImpl assertion = SamlTokenValidator.getSAMLAssertion(token);
-            String assertionIssuer = assertion.getIssuer().toString();
-            if(assertionIssuer == null)
-                throw new BusinessException("SAML issuer is null");
-            String trustedCertificate = Server.getInstance().getSamlTrustedCertificate(assertionIssuer);
-            if(trustedCertificate == null)
-                throw new BusinessException("Cannot find trusted certificate for this issuer");
-            email = SamlTokenValidator.getEmailIfValid(assertion, trustedCertificate, request.getRequestURL().toString());
-        } catch (CoreException ex) {
-            logger.info(ex.getMessage());
+            try {
+                // XML object might be a saml response. In this case, take the first assertion found
+                // (happens in FLI)
+                Response samlResponse = (Response) SamlTokenValidator.getSAMLObject(xmlAssertion);
+                List<Assertion> assertions = samlResponse.getAssertions();
+                assertion = assertions.get(0);
+            } catch (ClassCastException ex) {
+                // Otherwise, try to cast directly the XML object to Assertion (happens in Neugrid).
+                assertion = (Assertion) SamlTokenValidator.getSAMLObject(xmlAssertion);
+            }
+        } catch (UnsupportedEncodingException | ConfigurationException | XMLParserException | UnmarshallingException ex) {
+            java.util.logging.Logger.getLogger(SamlAuthenticationService.class.getName()).log(Level.SEVERE, null, ex);
+        }
+        if (assertion == null) {
+            throw new BusinessException("Cannot get assertion!");
+        }
+
+        // Find public key certificate to use from issuer
+        issuer = assertion.getIssuer();
+        if (issuer == null) {
+            throw new BusinessException("Cannot find assertion issuer!");
+        }
+        logger.info("Received SAML assertion from issuer " + issuer.getValue());
+        String certFile = Server.getInstance().getSamlTrustedCertificate(issuer.getValue());
+
+        // Check validity of assertion
+        try {
+            SamlTokenValidator.isSignatureValid(certFile, assertion);
+        } catch (CertificateException | IOException | NoSuchAlgorithmException | InvalidKeySpecException | ValidationException ex) {
+            throw new BusinessException("Assertion signature is not valid!");
+        }
+        if (!SamlTokenValidator.isTimeValid(assertion)) {
+            throw new BusinessException("Assertion is not time valid!");
+        }
+        try {
+            if (!SamlTokenValidator.isAudienceValid(request.getRequestURL().toString(), assertion)) {
+                throw new BusinessException("Assertion audience is not valid!");
+            }
+        } catch (MalformedURLException ex) {
             throw new BusinessException(ex);
         }
-        return email;
     }
 
     @Override
     public String getDefaultAccountType() {
-        return Server.getInstance().getSAMLDefaultAccountType();
+        return Server.getInstance().getSAMLAccountType(issuer);
     }
+
+    @Override
+    protected String getEmail() throws BusinessException {
+        return SamlTokenValidator.getEmail(assertion);
+    }
+
 }

--- a/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/ConfigurationBusiness.java
+++ b/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/ConfigurationBusiness.java
@@ -332,52 +332,6 @@ public class ConfigurationBusiness {
         }
     }
 
-    /**
-     *
-     * @param ticket
-     * @param password
-     * @return
-     * @throws BusinessException
-     */
-    public User signin(String ticket, URL serviceURL) throws BusinessException {
-
-        //validate ticket
-        User user = getCASUser(ticket, serviceURL);
-
-        if (user != null) {
-
-            UserDAO userDAO;
-            try {
-                userDAO = CoreDAOFactory.getDAOFactory().getUserDAO();
-            } catch (DAOException ex) {
-                throw new BusinessException(ex);
-            }
-            try {
-                user = userDAO.getUser(user.getEmail());
-                userDAO.resetNFailedAuthentications(user.getEmail());
-            } catch (DAOException ex) {
-                try {
-                    signup(user, "Generated from CAS login", true, true, Server.getInstance().getSAMLDefaultAccountType());
-                    this.activateUser(user.getEmail());
-                    user = userDAO.getUser(user.getEmail());
-
-                } catch (DAOException ex1) {
-                    throw new BusinessException(ex1);
-                }
-            }
-            try {
-                return getUserWithSession(user.getEmail());
-            } catch (DAOException e) {
-                throw new BusinessException(e);
-            }
-
-        } else {
-            logger.error("Authentication failed to CAS ticket '" + ticket + "' (invalid ticket, cannot get user email or cannot contact server).");
-            throw new BusinessException("Authentication failed (invalid CAS ticket, cannot get user email or cannot contact server).");
-        }
-
-    }
-
     public User getNewUser(String email, String firstName, String lastName) {
         CountryCode cc = CountryCode.aq;
 

--- a/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/Server.java
+++ b/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/Server.java
@@ -116,7 +116,6 @@ PropertiesConfiguration config;
     //undesired email domains
     private List<String> undesiredMailDomains;
     //third-party auth
-    private String samlTrustedCertificate;
     private String mozillaPersonaValidationURL;
     //treeQuery
     private String queryTree;
@@ -196,7 +195,6 @@ PropertiesConfiguration config;
             SAMLDefaultAccountType = config.getString(CoreConstants.LAB_SAML_ACCOUNT_TYPE, "Neuroimaging");
 
             sshPublicKey = config.getString(CoreConstants.SSH_PUBLIC_KEY, "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAuNjIXlgjuBR+WfjGtkieecZfe/ZL6EyNJTbL14bn3/Soof0kFSshDJvFgSH1hNwMMU1hynLbzcEbLTyVMoGQKfQkq7mJPajy9g8878WCKxCRbXv3W1/HT9iab/qqt2dcRYnDEruHwgyELBhQuMAe2W2/mgjd7Y5PxE01bwDcenYl3cU3iJk1sAOHao6P+3xU6Ov+TD8K9aC0LzZpM+rzAmS9HOZ9nvzERExd7k4TUpyffQV9Dpb5jEnEViF3VHqplB8AbWDdcJbiVkUBUe4hQb7nmWP0kHl1+v5SQJ1B4mWCZ+35Rc/9b1GsmPnXg3qqhjeKbrim/NbcUwKr9NPWjQ== vip-services@kingkong.grid.creatis.insa-lyon.fr");
-            samlTrustedCertificate = config.getString(CoreConstants.SAML_TRUSTED_CERTIFICATE, System.getProperty("user.home") + File.separator + ".vip" + File.separator + "trusted_saml_cert.pem");
             mozillaPersonaValidationURL = config.getString(CoreConstants.MOZILLA_PERSONA_VALIDATION_URL, "https://verifier.login.persona.org/verify");
             //
             List<String> appletGateLabCl = new ArrayList<String>();
@@ -272,11 +270,9 @@ PropertiesConfiguration config;
             config.setProperty(CoreConstants.LAB_CAS_URL, casURL);
             config.setProperty(CoreConstants.LAB_SAML_ACCOUNT_TYPE, SAMLDefaultAccountType);
             config.setProperty(CoreConstants.SSH_PUBLIC_KEY, sshPublicKey);
-            config.setProperty(CoreConstants.SAML_TRUSTED_CERTIFICATE, samlTrustedCertificate);
             config.setProperty(CoreConstants.MOZILLA_PERSONA_VALIDATION_URL, mozillaPersonaValidationURL);
             config.setProperty(CoreConstants.TreeQuery, queryTree);
-
-           
+       
             config.setProperty(CoreConstants.APPLICATION_FILES_REPOSITORY, applicationImporterFileRepository);
             config.setProperty(CoreConstants.APP_DELETE_FILES_AFTER_UPLOAD, deleteFilesAfterUpload);
             config.setProperty(CoreConstants.APPLET_GATELAB_CLASSES, appletGateLabClasses);
@@ -466,8 +462,11 @@ PropertiesConfiguration config;
         return sshPublicKey;
     }
 
-    public String getSamlTrustedCertificate() {
-        return samlTrustedCertificate;
+    public String getSamlTrustedCertificate(String issuer) {
+        logger.info("Getting trusted certificate for issuer "+issuer);
+        String result = config.getString(CoreConstants.SAML_TRUSTED_CERTIFICATE+"."+issuer);
+        logger.info("Returning "+result);
+        return result;
     }
 
     public String getMozillaPersonaValidationURL() {

--- a/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/Server.java
+++ b/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/Server.java
@@ -39,6 +39,7 @@ import java.util.List;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.log4j.Logger;
+import org.opensaml.saml2.core.Issuer;
 
 /**
  *
@@ -105,7 +106,6 @@ PropertiesConfiguration config;
     private int apacheSSLPort = 80;
     //cas
     private String casURL;
-    private String SAMLDefaultAccountType;
     //ssh
     private String sshPublicKey;
     //application,GateLab
@@ -192,7 +192,6 @@ PropertiesConfiguration config;
             apacheSSLPort = config.getInt("apache.ssl.port", apacheSSLPort);
 
             casURL = config.getString(CoreConstants.LAB_CAS_URL, "https://ng-cas.maatg.fr/pandora-gateway-sl-cas");
-            SAMLDefaultAccountType = config.getString(CoreConstants.LAB_SAML_ACCOUNT_TYPE, "Neuroimaging");
 
             sshPublicKey = config.getString(CoreConstants.SSH_PUBLIC_KEY, "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAuNjIXlgjuBR+WfjGtkieecZfe/ZL6EyNJTbL14bn3/Soof0kFSshDJvFgSH1hNwMMU1hynLbzcEbLTyVMoGQKfQkq7mJPajy9g8878WCKxCRbXv3W1/HT9iab/qqt2dcRYnDEruHwgyELBhQuMAe2W2/mgjd7Y5PxE01bwDcenYl3cU3iJk1sAOHao6P+3xU6Ov+TD8K9aC0LzZpM+rzAmS9HOZ9nvzERExd7k4TUpyffQV9Dpb5jEnEViF3VHqplB8AbWDdcJbiVkUBUe4hQb7nmWP0kHl1+v5SQJ1B4mWCZ+35Rc/9b1GsmPnXg3qqhjeKbrim/NbcUwKr9NPWjQ== vip-services@kingkong.grid.creatis.insa-lyon.fr");
             mozillaPersonaValidationURL = config.getString(CoreConstants.MOZILLA_PERSONA_VALIDATION_URL, "https://verifier.login.persona.org/verify");
@@ -268,7 +267,6 @@ PropertiesConfiguration config;
             config.setProperty("apache.host", apacheHost);
             config.setProperty("apache.ssl.port", apacheSSLPort);
             config.setProperty(CoreConstants.LAB_CAS_URL, casURL);
-            config.setProperty(CoreConstants.LAB_SAML_ACCOUNT_TYPE, SAMLDefaultAccountType);
             config.setProperty(CoreConstants.SSH_PUBLIC_KEY, sshPublicKey);
             config.setProperty(CoreConstants.MOZILLA_PERSONA_VALIDATION_URL, mozillaPersonaValidationURL);
             config.setProperty(CoreConstants.TreeQuery, queryTree);
@@ -454,10 +452,6 @@ PropertiesConfiguration config;
         return casURL;
     }
 
-    public String getSAMLDefaultAccountType() {
-        return SAMLDefaultAccountType;
-    }
-
     public String getSshPublicKey() {
         return sshPublicKey;
     }
@@ -465,6 +459,13 @@ PropertiesConfiguration config;
     public String getSamlTrustedCertificate(String issuer) {
         logger.info("Getting trusted certificate for issuer "+issuer);
         String result = config.getString(CoreConstants.SAML_TRUSTED_CERTIFICATE+"."+issuer);
+        logger.info("Returning "+result);
+        return result;
+    }
+    
+    public String getSAMLAccountType(Issuer issuer) {
+        logger.info("Getting account type for issuer "+issuer);
+        String result = config.getString(CoreConstants.SAML_ACCOUNT_TYPE+"."+issuer);
         logger.info("Returning "+result);
         return result;
     }
@@ -527,4 +528,5 @@ PropertiesConfiguration config;
         config.setProperty(CoreConstants.LAB_SIMULATION_PLATFORM_MAX, maxPlatformRunningSimulations);
         config.save();
     }
+
 }

--- a/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/Server.java
+++ b/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/Server.java
@@ -463,7 +463,7 @@ PropertiesConfiguration config;
         return result;
     }
     
-    public String getSAMLAccountType(Issuer issuer) {
+    public String getSAMLAccountType(String issuer) {
         logger.info("Getting account type for issuer "+issuer);
         String result = config.getString(CoreConstants.SAML_ACCOUNT_TYPE+"."+issuer);
         logger.info("Returning "+result);

--- a/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/rpc/ConfigurationServiceImpl.java
+++ b/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/rpc/ConfigurationServiceImpl.java
@@ -162,31 +162,6 @@ public class ConfigurationServiceImpl extends AbstractRemoteServiceServlet imple
 
     /**
      *
-     * @param ticket
-     * @throws CoreException
-     * @return
-     */
-    @Override
-    public User signin(String ticket) throws CoreException {
-
-        try {
-            logger.info("Authenticating CAS ticket '" + ticket + "'.");
-            User user = configurationBusiness.signin(ticket, getBaseURL());
-            user = setUserSession(user);
-            configurationBusiness.updateUserLastLogin(user.getEmail());
-            trace(logger, "Connected.");
-
-            return user;
-
-        } catch (BusinessException ex) {
-            throw new CoreException(ex);
-        } catch (MalformedURLException e) {
-            throw new CoreException(e);
-        }
-    }
-
-    /**
-     *
      * @throws CoreException
      */
     @Override

--- a/Portal/vip-portal/src/main/java/fr/insalyon/creatis/vip/portal/client/Main.java
+++ b/Portal/vip-portal/src/main/java/fr/insalyon/creatis/vip/portal/client/Main.java
@@ -65,7 +65,6 @@ public class Main implements EntryPoint {
     @Override
     public void onModuleLoad() {
 
-        final String ticket = Window.Location.getParameter("ticket");
         String login = Window.Location.getParameter("login");
 
         if (login.equals("stats")) {
@@ -86,12 +85,7 @@ public class Main implements EntryPoint {
         modulesInit.add(new CardiacModule());
         modulesInit.add(new ApplicationImporterModule());
 
-        if (ticket == null && (login == null || !login.equals("CASN4U"))) {
-            //regular VIP authentication
-            configureVIP();
-        } else {
-            configureN4U(ticket);
-        }
+        configureVIP();
     }
 
     //redirect to N4U CAS authentication
@@ -154,45 +148,6 @@ public class Main implements EntryPoint {
             }
         };
         service.configure(email, session, callback);
-    }
-
-    private void configureN4U(String ticket) {
-        //N4U authentication
-        if (ticket == null) {
-            //if the user has no ticket, get one
-            displayLoginView();
-        } else {
-            //sign in with N4U ticket
-            ConfigurationServiceAsync service = ConfigurationService.Util.getInstance();
-
-            final AsyncCallback<User> callback = new AsyncCallback<User>() {
-                @Override
-                public void onFailure(Throwable caught) {
-                    Layout.getInstance().getModal().hide();
-                    if (caught.getMessage().contains("Authentication failed")) {
-                        displayLoginView();
-                    } else {
-                        configureVIP();
-                    }
-                }
-
-                @Override
-                public void onSuccess(User user) {
-                    Layout.getInstance().getModal().hide();
-
-                    Cookies.setCookie(CoreConstants.COOKIES_USER,
-                            user.getEmail(), CoreConstants.COOKIES_EXPIRATION_DATE,
-                            null, "/", false);
-                    Cookies.setCookie(CoreConstants.COOKIES_SESSION,
-                            user.getSession(), CoreConstants.COOKIES_EXPIRATION_DATE,
-                            null, "/", false);
-
-                    Layout.getInstance().authenticate(user);
-                }
-            };
-            Layout.getInstance().getModal().show("Signing in with CAS...", true);
-            service.signin(ticket, callback);
-        }
     }
 
     private void configureStats() {


### PR DESCRIPTION
This pull request discards the CAS authentication method (Redmine #2277) and extends the SAML one so that multiple SAML providers can be trusted (#2874). To add a new SAML provider, the following 2 attributes need to be added to the configuration file:

saml.trustedcertificate.[issuer] = [path to public key certificate]
saml.accounttype.[issuer] = [name of a VIP account type]