### PR TITLE
Allow cross-origin requests

### DIFF
--- a/Portal/vip-portal/src/main/webapp/WEB-INF/web.xml
+++ b/Portal/vip-portal/src/main/webapp/WEB-INF/web.xml
@@ -253,4 +253,12 @@ knowledge of the CeCILL-B license and that you accept its terms.
         <res-type>javax.sql.DataSource</res-type>
         <res-auth>Container</res-auth>
     </resource-ref>
+    <filter>
+      <filter-name>CorsFilter</filter-name>
+      <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>
+    </filter>
+    <filter-mapping>
+      <filter-name>CorsFilter</filter-name>
+      <url-pattern>/*</url-pattern>
+    </filter-mapping>
 </web-app>


### PR DESCRIPTION
This is to allow JavaScript pages hosted elsewhere than on VIP to make queries to the API and display information. This is requested by FLI-IAM to use the VIP API in their portal. Ideally, this should be enabled only for the API and not for its authentication method. Currently, it is allowed for any page. 