### PR TITLE
Feature/api test refactoring

### DIFF
--- a/Portal/vip-api/pom.xml
+++ b/Portal/vip-api/pom.xml
@@ -32,7 +32,8 @@ knowledge of the CeCILL-B license and that you accept its terms.
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>fr.insalyon.creatis</groupId>
@@ -71,7 +72,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
                         <version>${cxf.version}</version>
                     </dependency>
                 </dependencies>
- 
+
                 <executions>
                     <execution>
                         <id>process-classes</id>
@@ -93,14 +94,14 @@ knowledge of the CeCILL-B license and that you accept its terms.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <cxf.version>2.2.3</cxf.version>
     </properties>
-    <dependencies> 
+    <dependencies>
         <dependency>
             <groupId>fr.insalyon.creatis</groupId>
             <artifactId>vip-application</artifactId>
             <version>${vip.application.version}</version>
             <scope>provided</scope>
         </dependency>
-         <dependency>
+        <dependency>
             <groupId>fr.insalyon.creatis</groupId>
             <artifactId>vip-core</artifactId>
             <version>${vip.core.version}</version>
@@ -127,5 +128,22 @@ knowledge of the CeCILL-B license and that you accept its terms.
             <artifactId>vip-core</artifactId>
             <version>${vip.core.version}</version>
         </dependency>-->
+
+        <!-- Test dependencies -->
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+        </dependency>
+
+        <!-- End test dependencies -->
+
     </dependencies>
 </project>

--- a/Portal/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/ApiBusiness.java
+++ b/Portal/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/ApiBusiness.java
@@ -1,7 +1,33 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright and authors: see LICENSE.txt in base repository.
+ *
+ * This software is a web portal for pipeline execution on distributed systems.
+ *
+ * This software is governed by the CeCILL-B license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-B
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-B license and that you accept its terms.
  */
 package fr.insalyon.creatis.vip.api.business;
 
@@ -14,8 +40,6 @@ import fr.insalyon.creatis.vip.core.server.dao.DAOException;
 import fr.insalyon.creatis.vip.core.server.dao.mysql.PlatformConnection;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-import java.util.ArrayList;
-import java.util.List;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -34,85 +58,58 @@ public class ApiBusiness {
     private final static Logger logger = Logger.getLogger(ApiBusiness.class);
     private final String authFailedMessage = "API user is not logged in.";
 
-    private final HttpSession session;
-    private final HttpServletRequest request;
-    private final HttpServletResponse response;
-    private User user;
-    
-    private List<String> warnings;
+    private final ConfigurationBusiness configurationBusiness;
 
-    public ApiBusiness(WebServiceContext wsContext, boolean authenticate) throws ApiException {
+    public ApiBusiness() {
+        this.configurationBusiness = new ConfigurationBusiness();
+    }
+
+    public ApiBusiness(ConfigurationBusiness configurationBusiness) {
+        this.configurationBusiness = configurationBusiness;
+    }
+
+    public ApiContext getApiContext(
+            WebServiceContext wsContext,
+            boolean authenticate) throws ApiException {
 
         try {
-            
-            warnings = new ArrayList<>();
-            
             // set logging properties and DB connection
             PropertyConfigurator.configure(ConfigurationBusiness.class.getClassLoader().getResource("vipLog4j.properties"));
             PlatformConnection.getInstance();
 
             //set request and response
             MessageContext mc = wsContext.getMessageContext();
-            request = (HttpServletRequest) mc.get(MessageContext.SERVLET_REQUEST);
-            response = (HttpServletResponse) mc.get(MessageContext.SERVLET_RESPONSE);
-
-            // set session
-            session = ((javax.servlet.http.HttpServletRequest) mc.get(MessageContext.SERVLET_REQUEST)).getSession();
+            HttpServletRequest request = (HttpServletRequest) mc.get(MessageContext.SERVLET_REQUEST);
+            HttpServletResponse response = (HttpServletResponse) mc.get(MessageContext.SERVLET_RESPONSE);
+            HttpSession session = request.getSession();
             if (session == null) {
                 throw new ApiException("No session in WebServiceContext");
             }
 
             // Authentication
+            User user = null;
             if (authenticate) {
-                user = authenticateSession();
+                user = authenticateSession(request, response);
             }
+            return new ApiContext(session, request, response, user);
         } catch (DAOException ex) {
             throw new ApiException(ex);
         }
     }
 
-    public ApiBusiness(ApiBusiness ab){
-        this.session = ab.getSession();
-        this.request = ab.getRequest();
-        this.response = ab.getResponse();
-        this.user = ab.getUser();
-        this.warnings = ab.getWarnings();
-    }
-    
-    public HttpSession getSession() {
-        return session;
-    }
-
-    public HttpServletRequest getRequest() {
-        return request;
-    }
-
-    public HttpServletResponse getResponse() {
-        return response;
-    }
-
-    public User getUser() {
-        return user;
-    }
-    
-    public List<String> getWarnings(){
-        return warnings;
-    }
-
-    protected final User authenticateSession() throws ApiException {
+    protected final User authenticateSession(HttpServletRequest request, HttpServletResponse response) throws ApiException {
         try {
             //verify session
-            ConfigurationBusiness configurationBusiness = new ConfigurationBusiness();
             String email = getCookieValue(request, CoreConstants.COOKIES_USER);
-            String sessionId = getCookieValue(getRequest(), CoreConstants.COOKIES_SESSION);
+            String sessionId = getCookieValue(request, CoreConstants.COOKIES_SESSION);
             if (email == null || sessionId == null) {
                 throw new ApiException(this.authFailedMessage);
             }
             email = URLDecoder.decode(email, "UTF-8");
             if (configurationBusiness.validateSession(email, sessionId)) {
                 logger.info("API successfully authenticated user " + email);
-                user = configurationBusiness.getUser(email);
-                AbstractAuthenticationService.setVIPSession(getRequest(), getResponse(), user);
+                User user = configurationBusiness.getUser(email);
+                AbstractAuthenticationService.setVIPSession(request, response, user);
                 configurationBusiness.updateUserLastLogin(email);
                 return user;
             }

--- a/Portal/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/ApiContext.java
+++ b/Portal/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/ApiContext.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright and authors: see LICENSE.txt in base repository.
+ *
+ * This software is a web portal for pipeline execution on distributed systems.
+ *
+ * This software is governed by the CeCILL-B license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-B
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-B license and that you accept its terms.
+ */
+package fr.insalyon.creatis.vip.api.business;
+
+import fr.insalyon.creatis.vip.core.client.bean.User;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by abonnet on 7/6/16.
+ */
+public class ApiContext {
+
+    private final HttpSession session;
+    private final HttpServletRequest request;
+    private final HttpServletResponse response;
+    private User user;
+    private List<String> warnings;
+
+    public ApiContext(HttpSession session, HttpServletRequest request, HttpServletResponse response, User user) {
+        this.session = session;
+        this.request = request;
+        this.response = response;
+        this.user = user;
+        this.warnings = new ArrayList<>();
+    }
+
+    public HttpSession getSession() {
+        return session;
+    }
+
+    public HttpServletRequest getRequest() {
+        return request;
+    }
+
+    public HttpServletResponse getResponse() {
+        return response;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public List<String> getWarnings() {
+        return warnings;
+    }
+}

--- a/Portal/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/ApiUtils.java
+++ b/Portal/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/ApiUtils.java
@@ -39,13 +39,13 @@ public class ApiUtils {
         }
     }
 
-    public static String getMessage(ApiBusiness eb) {
+    public static String getMessage(ApiContext apiContext) {
         String message;
-        if (eb.getWarnings().isEmpty()) {
+        if (apiContext.getWarnings().isEmpty()) {
             message = "OK";
         } else {
             message = "Warning: ";
-            for (String warning : eb.getWarnings()) {
+            for (String warning : apiContext.getWarnings()) {
                 message += warning + " ";
             }
         }

--- a/Portal/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/ExecutionBusiness.java
+++ b/Portal/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/ExecutionBusiness.java
@@ -46,6 +46,7 @@ import fr.insalyon.creatis.vip.application.client.bean.InOutData;
 import fr.insalyon.creatis.vip.application.client.bean.Simulation;
 import fr.insalyon.creatis.vip.application.client.view.monitor.SimulationStatus;
 import fr.insalyon.creatis.vip.application.server.business.ApplicationBusiness;
+import fr.insalyon.creatis.vip.application.server.business.ClassBusiness;
 import fr.insalyon.creatis.vip.application.server.business.SimulationBusiness;
 import fr.insalyon.creatis.vip.application.server.business.WorkflowBusiness;
 import fr.insalyon.creatis.vip.core.client.bean.Group;
@@ -61,30 +62,52 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.xml.ws.WebServiceContext;
 
 /**
  *
  * @author Tristan Glatard
  */
-public class ExecutionBusiness extends ApiBusiness {
+public class ExecutionBusiness {
 
     private final static org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(ExecutionBusiness.class);
 
-    public ExecutionBusiness(WebServiceContext wsContext) throws ApiException {
-        super(wsContext, true);
+    private final ApiContext apiContext;
+    private final SimulationBusiness simulationBusiness;
+    private final WorkflowBusiness workflowBusiness;
+    private final PipelineBusiness pipelineBusiness;
+    private final ConfigurationBusiness configurationBusiness;
+    private final ApplicationBusiness applicationBusiness;
+
+
+    public ExecutionBusiness(ApiContext apiContext) {
+        WorkflowBusiness workflowBusiness = new WorkflowBusiness();
+        ApplicationBusiness applicationBusiness = new ApplicationBusiness();
+        this.apiContext = apiContext;
+        this.simulationBusiness = new SimulationBusiness();
+        this.workflowBusiness = workflowBusiness;
+        this.configurationBusiness = new ConfigurationBusiness();
+        this.applicationBusiness = applicationBusiness;
+        this.pipelineBusiness = new PipelineBusiness(apiContext, workflowBusiness, applicationBusiness, new ClassBusiness());
     }
 
-    public ExecutionBusiness(ApiBusiness ab) {
-        super(ab);
+    public ExecutionBusiness(ApiContext apiContext,
+                             SimulationBusiness simulationBusiness,
+                             WorkflowBusiness workflowBusiness,
+                             ConfigurationBusiness configurationBusiness,
+                             ApplicationBusiness applicationBusiness,
+                             PipelineBusiness pipelineBusiness) {
+        this.apiContext = apiContext;
+        this.simulationBusiness = simulationBusiness;
+        this.workflowBusiness = workflowBusiness;
+        this.configurationBusiness = configurationBusiness;
+        this.applicationBusiness = applicationBusiness;
+        this.pipelineBusiness = pipelineBusiness;
     }
 
     public String getStdOut(String executionId) throws ApiException {
         try {
-            WorkflowBusiness wb = new WorkflowBusiness();
-            SimulationBusiness sb = new SimulationBusiness();
-            Simulation s = wb.getSimulation(executionId);
-            String stdout = sb.readFile(s.getID(), "", "workflow", ".out");
+            Simulation s = workflowBusiness.getSimulation(executionId);
+            String stdout = simulationBusiness.readFile(s.getID(), "", "workflow", ".out");
             return stdout;
         } catch (BusinessException ex) {
             throw new ApiException(ex);
@@ -93,10 +116,8 @@ public class ExecutionBusiness extends ApiBusiness {
 
     public String getStdErr(String executionId) throws ApiException {
         try {
-            WorkflowBusiness wb = new WorkflowBusiness();
-            SimulationBusiness sb = new SimulationBusiness();
-            Simulation s = wb.getSimulation(executionId);
-            String stderr = sb.readFile(s.getID(), "", "workflow", ".err");
+            Simulation s = workflowBusiness.getSimulation(executionId);
+            String stderr = simulationBusiness.readFile(s.getID(), "", "workflow", ".err");
             return stderr;
         } catch (BusinessException ex) {
             throw new ApiException(ex);
@@ -105,10 +126,8 @@ public class ExecutionBusiness extends ApiBusiness {
 
     public Execution getExecution(String executionId, boolean summarize) throws ApiException {
         try {
-            WorkflowBusiness wb = new WorkflowBusiness();
-
             // Get main execution object
-            Simulation s = wb.getSimulation(executionId);
+            Simulation s = workflowBusiness.getSimulation(executionId);
 
             // Return null if execution doesn't exist or is cleaned (cleaned status is not supported in Carmin)
             if (s == null || s.getStatus() == SimulationStatus.Cleaned) {
@@ -132,7 +151,7 @@ public class ExecutionBusiness extends ApiBusiness {
                 return e;
             
             // Inputs
-            List<InOutData> inputs = wb.getInputData(executionId, getUser().getFolder());
+            List<InOutData> inputs = workflowBusiness.getInputData(executionId, apiContext.getUser().getFolder());
             logger.info("Execution has " + inputs.size() + " inputs ");
             for (InOutData iod : inputs) {
                 ParameterTypedValue value = new ParameterTypedValue(ApiUtils.getCarminType(iod.getType()), iod.getPath());
@@ -142,7 +161,7 @@ public class ExecutionBusiness extends ApiBusiness {
             }
 
             // Outputs
-            List<InOutData> outputs = wb.getOutputData(executionId, getUser().getFolder());
+            List<InOutData> outputs = workflowBusiness.getOutputData(executionId, apiContext.getUser().getFolder());
             for (InOutData iod : outputs) {
                 ParameterTypedValue value = new ParameterTypedValue(ApiUtils.getCarminType(iod.getType()), iod.getPath());
                 StringKeyParameterValuePair skpv = new StringKeyParameterValuePair(iod.getProcessor(), value);
@@ -163,10 +182,9 @@ public class ExecutionBusiness extends ApiBusiness {
 
     public Execution[] listExecutions(int maxReturned) throws ApiException {
         try {
-            
-            WorkflowBusiness wb = new WorkflowBusiness();
-            List<Simulation> simulations = wb.getSimulations(
-                    getUser().getFullName(),
+
+            List<Simulation> simulations = workflowBusiness.getSimulations(
+                    apiContext.getUser().getFullName(),
                     null, // application
                     null, // status
                     null, // class
@@ -181,7 +199,7 @@ public class ExecutionBusiness extends ApiBusiness {
                     count++;
                     executions.add(getExecution(s.getID(),true));
                     if(count >= maxReturned){
-                        getWarnings().add("Only the "+maxReturned+" most recent pipelines were returned.");
+                        apiContext.getWarnings().add("Only the "+maxReturned+" most recent pipelines were returned.");
                         break;
                     }
                 }
@@ -228,14 +246,13 @@ public class ExecutionBusiness extends ApiBusiness {
             // So we will just launch the execution, and launch an error in case playExecution is not true.
             // Set warnings
             if (studyId != null) {
-                getWarnings().add("Study identifier was ignored.");
+                apiContext.getWarnings().add("Study identifier was ignored.");
             }
             if (timeoutInSeconds != null && timeoutInSeconds != 0) {
-                getWarnings().add("Timeout value (" + timeoutInSeconds.toString() + ") was ignored.");
+                apiContext.getWarnings().add("Timeout value (" + timeoutInSeconds.toString() + ") was ignored.");
             }
 
             // Build input parameter map
-            WorkflowBusiness wb = new WorkflowBusiness();
             Map<String, String> pm = new HashMap<>();
             for (StringKeyParameterValuePair skpvp : inputValues) {
                 logger.info("Adding value " + skpvp.getValue().getValue() + " to input " + skpvp.getName());
@@ -243,8 +260,7 @@ public class ExecutionBusiness extends ApiBusiness {
             }
 
             // Check that all pipeline inputs are present
-            PipelineBusiness pb = new PipelineBusiness(this);
-            Pipeline p = pb.getPipeline(pipelineId);
+            Pipeline p = pipelineBusiness.getPipeline(pipelineId);
             for (PipelineParameter pp : p.getParameters()) {
                 if (pp.isReturnedValue()) {
                     continue;
@@ -268,9 +284,8 @@ public class ExecutionBusiness extends ApiBusiness {
             }
 
             // Get user groups
-            ConfigurationBusiness cb = new ConfigurationBusiness();
             List<String> groupNames = new ArrayList<>();
-            for (Group g : cb.getUserGroups(getUser().getEmail()).keySet()) {
+            for (Group g : configurationBusiness.getUserGroups(apiContext.getUser().getEmail()).keySet()) {
                 groupNames.add(g.getName());
             }
 
@@ -279,14 +294,13 @@ public class ExecutionBusiness extends ApiBusiness {
             String applicationVersion = ApiUtils.getApplicationVersion(pipelineId);
 
             // Get application classes
-            ApplicationBusiness ab = new ApplicationBusiness();
-            List<String> classes = ab.getApplication(applicationName).getApplicationClasses();
+            List<String> classes = applicationBusiness.getApplication(applicationName).getApplicationClasses();
             if (classes.isEmpty()) {
                 throw new ApiException("Application " + applicationName + " cannot be launched because it doesn't belong to any VIP class.");
             }
 
             logger.info("Launching workflow with the following parameters: ");
-            logger.info(getUser());
+            logger.info(apiContext.getUser());
             logger.info(groupNames);
             logger.info(pm);
             logger.info(applicationName);
@@ -295,7 +309,7 @@ public class ExecutionBusiness extends ApiBusiness {
             logger.info(executionName);
 
             // Launch the workflow
-            String executionId = wb.launch(getUser(),
+            String executionId = workflowBusiness.launch(apiContext.getUser(),
                                            groupNames,
                                            pm,
                                            applicationName,
@@ -313,18 +327,16 @@ public class ExecutionBusiness extends ApiBusiness {
         try {
             // Execution cannot be "played" (i.e. started) because it was already started in initExecution method.
             // So we just return the execution status.
-            WorkflowBusiness wb = new WorkflowBusiness();
-            getWarnings().add("In VIP, playExecution only returns the status of the execution.");
-            return VIPtoCarminStatus(wb.getSimulation(executionId).getStatus());
+            apiContext.getWarnings().add("In VIP, playExecution only returns the status of the execution.");
+            return VIPtoCarminStatus(workflowBusiness.getSimulation(executionId).getStatus());
         } catch (BusinessException ex) {
             throw new ApiException(ex);
         }
     }
 
     public void killExecution(String executionId) throws ApiException {
-        WorkflowBusiness wb = new WorkflowBusiness();
         try {
-            wb.kill(executionId);
+            workflowBusiness.kill(executionId);
         } catch (BusinessException ex) {
             throw new ApiException(ex);
         }
@@ -332,15 +344,14 @@ public class ExecutionBusiness extends ApiBusiness {
 
     public void deleteExecution(String executionId, Boolean deleteFiles) throws ApiException {
         checkIfUserCanAccessExecution(executionId);
-        WorkflowBusiness wb = new WorkflowBusiness();
         try {
-            Simulation s = wb.getSimulation(executionId);
+            Simulation s = workflowBusiness.getSimulation(executionId);
             if (s.getStatus() != SimulationStatus.Completed && s.getStatus() != SimulationStatus.Killed) {
                 throw new ApiException("Cannot delete execution " + executionId + " because status is " + s.getStatus().toString());
             }
             // Note: this won't delete the intermediate files in case the execution was run locally, which violates the spec.
             // Purge should be called in that case but purge also violates the spec.
-            wb.clean(executionId, getUser().getEmail(), deleteFiles);
+            workflowBusiness.clean(executionId, apiContext.getUser().getEmail(), deleteFiles);
         } catch (BusinessException ex) {
             throw new ApiException(ex);
         }
@@ -360,13 +371,12 @@ public class ExecutionBusiness extends ApiBusiness {
             ArrayList<String> urls = new ArrayList<>();
 
             TransferPoolBusiness tpb = new TransferPoolBusiness();
-            WorkflowBusiness wb = new WorkflowBusiness();
-            List<InOutData> outputs = wb.getOutputData(executionId, getUser().getFolder());
+            List<InOutData> outputs = workflowBusiness.getOutputData(executionId, apiContext.getUser().getFolder());
             for (InOutData output : outputs) {
 
-                String operationId = tpb.downloadFile(getUser(), output.getPath());
+                String operationId = tpb.downloadFile(apiContext.getUser(), output.getPath());
 
-                String url = getRequest().getRequestURL() + "/../fr.insalyon.creatis.vip.portal.Main/filedownloadservice?operationid=" + operationId;
+                String url = apiContext.getRequest().getRequestURL() + "/../fr.insalyon.creatis.vip.portal.Main/filedownloadservice?operationid=" + operationId;
                 URL u = new URL(url); // just to check that it is a well-formed URL
                 urls.add(url);
             }
@@ -401,12 +411,11 @@ public class ExecutionBusiness extends ApiBusiness {
 
     public void checkIfUserCanAccessExecution(String executionId) throws ApiException {
         try {
-            User user = getUser();
+            User user = apiContext.getUser();
             if (user.isSystemAdministrator()) {
                 return;
             }
-            WorkflowBusiness wb = new WorkflowBusiness();
-            Simulation s = wb.getSimulation(executionId);
+            Simulation s = workflowBusiness.getSimulation(executionId);
             if (s.getUserName().equals(user.getEmail())) {
                 return;
             }

--- a/Portal/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/GlobalPropertiesBusiness.java
+++ b/Portal/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/GlobalPropertiesBusiness.java
@@ -34,19 +34,20 @@ package fr.insalyon.creatis.vip.api.business;
 import fr.insalyon.creatis.vip.api.bean.GlobalProperties;
 import fr.insalyon.creatis.vip.api.bean.Module;
 import fr.insalyon.creatis.vip.core.server.business.Server;
-import javax.xml.ws.WebServiceContext;
 import org.apache.log4j.Logger;
 
 /**
  *
  * @author Tristan Glatard
  */
-public class GlobalPropertiesBusiness extends ApiBusiness {
+public class GlobalPropertiesBusiness {
 
     private final static Logger logger = Logger.getLogger(GlobalPropertiesBusiness.class);
-    
-    public GlobalPropertiesBusiness(WebServiceContext wsContext) throws ApiException {
-        super(wsContext,false);
+
+    private final ApiContext apiContext;
+
+    public GlobalPropertiesBusiness(ApiContext apiContext) {
+        this.apiContext = apiContext;
     }
 
     public GlobalProperties getGlobalProperties() throws ApiException {

--- a/Portal/vip-api/src/main/java/fr/insalyon/creatis/vip/api/soap/Carmin.java
+++ b/Portal/vip-api/src/main/java/fr/insalyon/creatis/vip/api/soap/Carmin.java
@@ -38,15 +38,9 @@ import fr.insalyon.creatis.vip.api.bean.Pipeline;
 import fr.insalyon.creatis.vip.api.bean.pairs.StringKeyParameterValuePair;
 import fr.insalyon.creatis.vip.api.bean.pairs.StringKeyValuePair;
 import fr.insalyon.creatis.vip.api.bean.Response;
-import fr.insalyon.creatis.vip.api.bean.pairs.PairOfPipelineAndBooleanLists;
-import fr.insalyon.creatis.vip.api.business.ApiException;
-import fr.insalyon.creatis.vip.api.business.ApiUtils;
-import fr.insalyon.creatis.vip.api.business.AuthenticationBusiness;
-import fr.insalyon.creatis.vip.api.business.ExecutionBusiness;
-import fr.insalyon.creatis.vip.api.business.GlobalPropertiesBusiness;
-import fr.insalyon.creatis.vip.api.business.PipelineBusiness;
+import fr.insalyon.creatis.vip.api.business.*;
+
 import java.util.ArrayList;
-import java.util.List;
 import javax.annotation.Resource;
 import javax.jws.WebService;
 import javax.jws.WebMethod;
@@ -89,10 +83,11 @@ public class Carmin {
         try {
             ApiUtils.methodInvocationLog("getExecution", executionId);
             ApiUtils.throwIfNull(executionId, "Execution id");
-            ExecutionBusiness eb = new ExecutionBusiness(wsContext);
+            ApiContext apiContext = new ApiBusiness().getApiContext(wsContext, true);
+            ExecutionBusiness eb = new ExecutionBusiness(apiContext);
             eb.checkIfUserCanAccessExecution(executionId);
             Execution e = eb.getExecution(executionId,false);
-            r = new Response(0, ApiUtils.getMessage(eb), e);
+            r = new Response(0, ApiUtils.getMessage(apiContext), e);
         } catch (ApiException ex) {
             logger.error(ex);
             r = new Response(1, ex.getMessage(), null);
@@ -106,9 +101,10 @@ public class Carmin {
         Response r;
         try {
             ApiUtils.methodInvocationLog("listExecutions");
-            ExecutionBusiness eb = new ExecutionBusiness(wsContext);
+            ApiContext apiContext = new ApiBusiness().getApiContext(wsContext, true);
+            ExecutionBusiness eb = new ExecutionBusiness(apiContext);
             Execution[] executions = eb.listExecutions(500); // will not return more than 500 executions.
-            r = new Response(0, ApiUtils.getMessage(eb), executions);
+            r = new Response(0, ApiUtils.getMessage(apiContext), executions);
         } catch (ApiException ex) {
             logger.error(ex);
             r = new Response(1, ex.getMessage(), null);
@@ -122,9 +118,10 @@ public class Carmin {
         Response r;
         try {
             ApiUtils.methodInvocationLog("getStdOut",executionId);
-            ExecutionBusiness eb = new ExecutionBusiness(wsContext);
+            ApiContext apiContext = new ApiBusiness().getApiContext(wsContext, true);
+            ExecutionBusiness eb = new ExecutionBusiness(apiContext);
             String stdout = eb.getStdOut(executionId);
-            r = new Response(0, ApiUtils.getMessage(eb), stdout);
+            r = new Response(0, ApiUtils.getMessage(apiContext), stdout);
         } catch (ApiException ex) {
             logger.error(ex);
             r = new Response(1, ex.getMessage(), null);
@@ -138,9 +135,10 @@ public class Carmin {
         Response r;
         try {
             ApiUtils.methodInvocationLog("getStdErr",executionId);
-            ExecutionBusiness eb = new ExecutionBusiness(wsContext);
+            ApiContext apiContext = new ApiBusiness().getApiContext(wsContext, true);
+            ExecutionBusiness eb = new ExecutionBusiness(apiContext);
             String stderr = eb.getStdErr(executionId);
-            r = new Response(0, ApiUtils.getMessage(eb), stderr);
+            r = new Response(0, ApiUtils.getMessage(apiContext), stderr);
         } catch (ApiException ex) {
             logger.error(ex);
             r = new Response(1, ex.getMessage(), null);
@@ -158,10 +156,11 @@ public class Carmin {
             ApiUtils.methodInvocationLog("updateExecution", executionId, keyValuePairs);
             ApiUtils.throwIfNull(executionId, "Execution id"); 
             ApiUtils.throwIfNull(keyValuePairs, "Values");
-            ExecutionBusiness eb = new ExecutionBusiness(wsContext);
+            ApiContext apiContext = new ApiBusiness().getApiContext(wsContext, true);
+            ExecutionBusiness eb = new ExecutionBusiness(apiContext);
             eb.checkIfUserCanAccessExecution(executionId);
             eb.updateExecution(executionId, keyValuePairs);
-            r = new Response(0, ApiUtils.getMessage(eb), null);
+            r = new Response(0, ApiUtils.getMessage(apiContext), null);
         } catch (ApiException ex) {
             logger.error(ex);
             r = new Response(1, ex.getMessage(), null);
@@ -188,11 +187,12 @@ public class Carmin {
             }
             if(executionName == null)
                 executionName = "Untitled";
-            PipelineBusiness pb = new PipelineBusiness(wsContext);
+            ApiContext apiContext = new ApiBusiness().getApiContext(wsContext, true);
+            PipelineBusiness pb = new PipelineBusiness(apiContext);
             pb.checkIfUserCanAccessPipeline(pipelineId);
-            ExecutionBusiness eb = new ExecutionBusiness(pb);
+            ExecutionBusiness eb = new ExecutionBusiness(apiContext);
             String id = eb.initExecution(pipelineId, inputValues, timeout, executionName, studyId, playExecution);
-            r = new Response(0, ApiUtils.getMessage(eb), id);
+            r = new Response(0, ApiUtils.getMessage(apiContext), id);
         } catch (ApiException ex) {
             logger.error(ex);
             r = new Response(1, ex.getMessage(), null);
@@ -207,10 +207,11 @@ public class Carmin {
         try {
             ApiUtils.methodInvocationLog("playExecution", executionId);
             ApiUtils.throwIfNull(executionId, "Execution id");
-            ExecutionBusiness eb = new ExecutionBusiness(wsContext);
+            ApiContext apiContext = new ApiBusiness().getApiContext(wsContext, true);
+            ExecutionBusiness eb = new ExecutionBusiness(apiContext);
             eb.checkIfUserCanAccessExecution(executionId);
             ExecutionStatus s = eb.playExecution(executionId);
-            r = new Response(0, ApiUtils.getMessage(eb), s);
+            r = new Response(0, ApiUtils.getMessage(apiContext), s);
         } catch (ApiException ex) {
             logger.error(ex);
             r = new Response(1, ex.getMessage(), null);
@@ -225,10 +226,11 @@ public class Carmin {
         try {
             ApiUtils.methodInvocationLog("killExecution", executionId);
             ApiUtils.throwIfNull(executionId, "Execution id");
-            ExecutionBusiness eb = new ExecutionBusiness(wsContext);
+            ApiContext apiContext = new ApiBusiness().getApiContext(wsContext, true);
+            ExecutionBusiness eb = new ExecutionBusiness(apiContext);
             eb.checkIfUserCanAccessExecution(executionId);
             eb.killExecution(executionId);
-            r = new Response(0, ApiUtils.getMessage(eb), null);
+            r = new Response(0, ApiUtils.getMessage(apiContext), null);
         } catch (ApiException ex) {
             logger.error(ex);
             r = new Response(1, ex.getMessage(), null);
@@ -245,10 +247,11 @@ public class Carmin {
         try {
             ApiUtils.methodInvocationLog("deleteExecution", executionId, deleteFiles);
             ApiUtils.throwIfNull(executionId, "Execution id");
-            ExecutionBusiness eb = new ExecutionBusiness(wsContext);
+            ApiContext apiContext = new ApiBusiness().getApiContext(wsContext, true);
+            ExecutionBusiness eb = new ExecutionBusiness(apiContext);
             eb.checkIfUserCanAccessExecution(executionId);
             eb.deleteExecution(executionId, deleteFiles);
-            r = new Response(0, ApiUtils.getMessage(eb), null);
+            r = new Response(0, ApiUtils.getMessage(apiContext), null);
         } catch (ApiException ex) {
             logger.error(ex);
             r = new Response(1, ex.getMessage(), null);
@@ -265,10 +268,11 @@ public class Carmin {
         try {
             ApiUtils.methodInvocationLog("getExecutionResults", executionId, protocol);
             ApiUtils.throwIfNull(executionId, "Execution id");
-            ExecutionBusiness eb = new ExecutionBusiness(wsContext);
+            ApiContext apiContext = new ApiBusiness().getApiContext(wsContext, true);
+            ExecutionBusiness eb = new ExecutionBusiness(apiContext);
             eb.checkIfUserCanAccessExecution(executionId);
             String[] results = eb.getExecutionResults(executionId, protocol);
-            r = new Response(0, ApiUtils.getMessage(eb), results);
+            r = new Response(0, ApiUtils.getMessage(apiContext), results);
         } catch (ApiException ex) {
             logger.error(ex);
             r = new Response(1, ex.getMessage(), null);
@@ -287,9 +291,10 @@ public class Carmin {
         Response r;
         try {
             ApiUtils.methodInvocationLog("getGlobalProperties");
-            GlobalPropertiesBusiness bpb = new GlobalPropertiesBusiness(wsContext);
+            ApiContext apiContext = new ApiBusiness().getApiContext(wsContext, false);
+            GlobalPropertiesBusiness bpb = new GlobalPropertiesBusiness(apiContext);
             GlobalProperties gp = bpb.getGlobalProperties();
-            r = new Response(0, ApiUtils.getMessage(bpb), gp);
+            r = new Response(0, ApiUtils.getMessage(apiContext), gp);
         } catch (ApiException ex) {
             logger.error(ex);
             r = new Response(1, ex.getMessage(), null);
@@ -309,10 +314,11 @@ public class Carmin {
         try {
             ApiUtils.methodInvocationLog("getPipeline", pipelineId); 
             ApiUtils.throwIfNull(pipelineId, "Pipeline id");
-            PipelineBusiness pb = new PipelineBusiness(wsContext);
+            ApiContext apiContext = new ApiBusiness().getApiContext(wsContext, true);
+            PipelineBusiness pb = new PipelineBusiness(apiContext);
             pb.checkIfUserCanAccessPipeline(pipelineId);
             Pipeline p = pb.getPipeline(pipelineId);
-            r = new Response(0, ApiUtils.getMessage(pb), p);
+            r = new Response(0, ApiUtils.getMessage(apiContext), p);
         } catch (ApiException ex) {
             logger.error(ex);
             r = new Response(1, ex.getMessage(), null);
@@ -325,10 +331,11 @@ public class Carmin {
     Response listPipelines(@WebParam(name = "studyIdentifier") String studyIdentifier) {
         Response r;
         try {
-            ApiUtils.methodInvocationLog("listPipelines", studyIdentifier);   
-            PipelineBusiness pb = new PipelineBusiness(wsContext);
+            ApiUtils.methodInvocationLog("listPipelines", studyIdentifier);
+            ApiContext apiContext = new ApiBusiness().getApiContext(wsContext, true);
+            PipelineBusiness pb = new PipelineBusiness(apiContext);
             Pipeline[] pipelines = pb.listPipelines(studyIdentifier);
-            r = new Response(0, ApiUtils.getMessage(pb),pipelines);
+            r = new Response(0, ApiUtils.getMessage(apiContext),pipelines);
         } catch (ApiException ex) {
             logger.error(ex);
             r = new Response(1, ex.getMessage(), null);
@@ -349,9 +356,10 @@ public class Carmin {
             ApiUtils.methodInvocationLog("authenticateSession", userName, "*****");
             ApiUtils.throwIfNull(userName, "User name");
             ApiUtils.throwIfNull(password, "Password");
-            AuthenticationBusiness ab = new AuthenticationBusiness(wsContext);
+            ApiContext apiContext = new ApiBusiness().getApiContext(wsContext, false);
+            AuthenticationBusiness ab = new AuthenticationBusiness(apiContext);
             ab.authenticateSession(userName, password);
-            r = new Response(0, ApiUtils.getMessage(ab), null);
+            r = new Response(0, ApiUtils.getMessage(apiContext), null);
         } catch (ApiException ex) {
             logger.error(ex);
             r = new Response(1, ex.getMessage(), null);
@@ -364,9 +372,10 @@ public class Carmin {
     Response authenticateHTTP(@XmlElement(required = true) @WebParam(name = "userName") String userName) {
         Response r;
         try {
-            AuthenticationBusiness ab = new AuthenticationBusiness(wsContext);
+            ApiContext apiContext = new ApiBusiness().getApiContext(wsContext, false);
+            AuthenticationBusiness ab = new AuthenticationBusiness(apiContext);
             ab.authenticateHTTP(userName);
-            r = new Response(0, ApiUtils.getMessage(ab), null);
+            r = new Response(0, ApiUtils.getMessage(apiContext), null);
         } catch (ApiException ex) {
             logger.error(ex);
             r = new Response(1, ex.getMessage(), null);
@@ -379,10 +388,11 @@ public class Carmin {
     Response logout() {
         Response r;
         try {
+            ApiContext apiContext = new ApiBusiness().getApiContext(wsContext, true);
             ApiUtils.methodInvocationLog("logout");
-            AuthenticationBusiness ab = new AuthenticationBusiness(wsContext);
+            AuthenticationBusiness ab = new AuthenticationBusiness(apiContext);
             ab.logout();
-            r = new Response(0, ApiUtils.getMessage(ab), null);
+            r = new Response(0, ApiUtils.getMessage(apiContext), null);
         } catch (ApiException ex) {
             logger.error(ex);
             r = new Response(1, ex.getMessage(), null);

--- a/Portal/vip-api/src/test/java/fr/insalyon/creatis/vip/api/business/ExecutionBusinessTest.java
+++ b/Portal/vip-api/src/test/java/fr/insalyon/creatis/vip/api/business/ExecutionBusinessTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright and authors: see LICENSE.txt in base repository.
+ *
+ * This software is a web portal for pipeline execution on distributed systems.
+ *
+ * This software is governed by the CeCILL-B license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-B
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-B license and that you accept its terms.
+ */
+package fr.insalyon.creatis.vip.api.business;
+
+import fr.insalyon.creatis.vip.application.client.bean.Simulation;
+import fr.insalyon.creatis.vip.application.client.view.monitor.SimulationStatus;
+import fr.insalyon.creatis.vip.application.server.business.WorkflowBusiness;
+import fr.insalyon.creatis.vip.core.client.bean.User;
+import fr.insalyon.creatis.vip.core.client.view.CoreConstants;
+import fr.insalyon.creatis.vip.core.client.view.user.UserLevel;
+import fr.insalyon.creatis.vip.core.server.business.BusinessException;
+import fr.insalyon.creatis.vip.core.server.business.ConfigurationBusiness;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import javax.xml.ws.WebServiceContext;
+import javax.xml.ws.handler.MessageContext;
+
+/**
+ * Created by abonnet on 7/6/16.
+ */
+public class ExecutionBusinessTest {
+
+    public static final String[] USER_FIRST_NAME = {"firstName_1", "firstName_2"};
+    public static final String[] USER_LAST_NAME = {"lastName_1", "lastName_2"};
+    public static final String[] USER_MAIL = {"mail_1@test.tst", "mail_2@test.tst"};
+    public static final String EXEC_ID = "exec-test-1";
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void checkIfAdminCanAccessAnyExecution() throws Exception {
+        ApiContext apiContext = new ApiContext(null, null, null, prepareTestUser(0, true));
+        WorkflowBusiness mockedWb = prepareMockedWorkflowBusiness(EXEC_ID, new Simulation());
+        ExecutionBusiness sut = new ExecutionBusiness(apiContext, null, mockedWb, null, null, null);
+        sut.checkIfUserCanAccessExecution(EXEC_ID);
+    }
+
+    @Test
+    public void checkIfBasicUserCannotAccessAnyExecution() throws Exception {
+        ApiContext apiContext = new ApiContext(null, null, null, prepareTestUser(0, false));
+        Simulation simulation = prepareSimulation(EXEC_ID, 1); // choose a different user
+        WorkflowBusiness mockedWb = prepareMockedWorkflowBusiness(EXEC_ID, simulation);
+        ExecutionBusiness sut = new ExecutionBusiness(apiContext, null, mockedWb, null, null, null);
+        exception.expect(ApiException.class);
+        exception.expectMessage("Permission denied");
+        sut.checkIfUserCanAccessExecution(EXEC_ID);
+    }
+
+    //@Test
+    public void checkIfBasicUserCanAccessItsExecution() throws Exception {
+        ApiContext apiContext = new ApiContext(null, null, null, prepareTestUser(0, false));
+        Simulation simulation = prepareSimulation(EXEC_ID, 0); // the creator of the execution is the same user
+        WorkflowBusiness mockedWb = prepareMockedWorkflowBusiness(EXEC_ID, simulation);
+        ExecutionBusiness sut = new ExecutionBusiness(apiContext, null, mockedWb, null, null, null);
+        sut.checkIfUserCanAccessExecution(EXEC_ID);
+    }
+
+    // UTILS to be externalized later
+
+    private User prepareTestUser(int userIndex, boolean isAdmin) {
+        return new User(USER_FIRST_NAME[userIndex], USER_LAST_NAME[userIndex], USER_MAIL[userIndex], null, null,
+                isAdmin ? UserLevel.Administrator : UserLevel.Beginner, null);
+    }
+
+    private Simulation prepareSimulation(String exedId, int userIndex) {
+        User creator = prepareTestUser(userIndex, false);
+        return new Simulation(null, null, null, exedId, creator.getFullName(), null, null,
+                SimulationStatus.Running.name(), null);
+    }
+
+    private WorkflowBusiness prepareMockedWorkflowBusiness(String execId, Simulation simu) throws Exception {
+        WorkflowBusiness mockedWb = Mockito.mock(WorkflowBusiness.class);
+        Mockito.when(mockedWb.getSimulation(execId)).thenReturn(simu);
+        return mockedWb;
+    }
+
+}


### PR DESCRIPTION
In order to make the API business classes testable, I made the following changes :
- Api business do not create dependencies on demand with "new". These dependencies are now injected in constructor.
- Common API business is not done in common superclass constructor, but in a separate dependency. A class ApiContext is created to contain the per-request API information (http stuff, user, warnings) and each API method take it in input.

To illustrate the goal of these changes, I created some unit test where dependencies are mocked (with the mockito library) which demonstrate the bug #2983. The failing test is commented to not block the maven build.