### PR TITLE
ignore maven target and IntelliJ files in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# idea
+.idea/
+*.iml
+
+#maven
+target/
+


### PR DESCRIPTION
Add a gitignore file to not pollute git status output with local files (maven's target directory + IDE configuration files).