### PR TITLE
remove useless gwt maven builds

### DIFF
--- a/Portal/vip-application-importer/pom.xml
+++ b/Portal/vip-application-importer/pom.xml
@@ -118,22 +118,6 @@ knowledge of the CeCILL-B license and that you accept its terms.
                     <target>1.8</target>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>gwt-maven-plugin</artifactId>
-                <version>2.5.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>test</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <hostedWebapp>${project.build.directory}/${project.build.finalName}</hostedWebapp>
-                </configuration>
-            </plugin>
             
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/Portal/vip-application/pom.xml
+++ b/Portal/vip-application/pom.xml
@@ -184,22 +184,6 @@ knowledge of the CeCILL-B license and that you accept its terms.
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>gwt-maven-plugin</artifactId>
-                <version>2.5.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>test</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <hostedWebapp>${project.build.directory}/${project.build.finalName}</hostedWebapp>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>

--- a/Portal/vip-core/pom.xml
+++ b/Portal/vip-core/pom.xml
@@ -214,22 +214,6 @@ knowledge of the CeCILL-B license and that you accept its terms.
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>gwt-maven-plugin</artifactId>
-                <version>2.5.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>test</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <hostedWebapp>${project.build.directory}/${project.build.finalName}</hostedWebapp>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>

--- a/Portal/vip-datamanagement/pom.xml
+++ b/Portal/vip-datamanagement/pom.xml
@@ -79,22 +79,6 @@ knowledge of the CeCILL-B license and that you accept its terms.
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>gwt-maven-plugin</artifactId>
-                <version>2.5.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>test</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <hostedWebapp>${project.build.directory}/${project.build.finalName}</hostedWebapp>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>

--- a/Portal/vip-docs/pom.xml
+++ b/Portal/vip-docs/pom.xml
@@ -73,22 +73,6 @@ knowledge of the CeCILL-B license and that you accept its terms.
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>gwt-maven-plugin</artifactId>
-                <version>2.5.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>test</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <hostedWebapp>${project.build.directory}/${project.build.finalName}</hostedWebapp>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>

--- a/Portal/vip-gatelab/pom.xml
+++ b/Portal/vip-gatelab/pom.xml
@@ -87,22 +87,6 @@ knowledge of the CeCILL-B license and that you accept its terms.
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>gwt-maven-plugin</artifactId>
-                <version>2.5.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>test</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <hostedWebapp>${project.build.directory}/${project.build.finalName}</hostedWebapp>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>

--- a/Portal/vip-social/pom.xml
+++ b/Portal/vip-social/pom.xml
@@ -77,22 +77,6 @@ knowledge of the CeCILL-B license and that you accept its terms.
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>gwt-maven-plugin</artifactId>
-                <version>2.5.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>test</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <hostedWebapp>${project.build.directory}/${project.build.finalName}</hostedWebapp>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
Make the gwt compilation only once, when the vip-portal war is created.

It gains a lot of time (1 min 50 vs 6 min 20 for a complete build on ma machine).