### PR TITLE
dont send group mail to locked users

### DIFF
--- a/Portal/vip-social/src/main/java/fr/insalyon/creatis/vip/social/server/business/MessageBusiness.java
+++ b/Portal/vip-social/src/main/java/fr/insalyon/creatis/vip/social/server/business/MessageBusiness.java
@@ -190,7 +190,10 @@ public class MessageBusiness {
                 ConfigurationBusiness configurationBusiness = new ConfigurationBusiness();
                 List<String> users = new ArrayList<String>();
                 for (User u : configurationBusiness.getUsers()) {
-                    users.add(u.getEmail());
+                    // Dont send mail to locked users
+                    if (!u.isAccountLocked()) {
+                        users.add(u.getEmail());
+                    }
                 }
                 recipients = users.toArray(new String[]{});
             }
@@ -279,7 +282,9 @@ public class MessageBusiness {
                     + "</html>";
 
             for (User u : users) {
-                if (!u.getEmail().equals(user.getEmail())) {
+                // Dont send mail to locked users and to itself
+                if (!u.isAccountLocked() &&
+                        !u.getEmail().equals(user.getEmail())) {
                     CoreUtil.sendEmail("VIP Message: " + subject + " (" + groupName + ")",
                             emailContent, new String[]{u.getEmail()}, true, user.getEmail());
                 }


### PR DESCRIPTION
Ticket 2972.

Do not include locked users in the following cases :
- mail send to all users
- mail send to a specific group in VIP portal

In particular, it doesn't (yet) concern mails sent to the vip-support group from :
- the portal to report an issue
- VIP itself in case of problem

I didn't thought it necessary because the group vip-support is well managed and, for the second case, it concerns several places in the code base. But I can work on that if necessary.