### PR TITLE
Fix missing dependency definitions

### DIFF
--- a/Portal/vip-application-importer/pom.xml
+++ b/Portal/vip-application-importer/pom.xml
@@ -95,6 +95,12 @@ knowledge of the CeCILL-B license and that you accept its terms.
         </dependency>
      
         <dependency>
+            <groupId>org.apache</groupId>
+            <artifactId>velocity-tools</artifactId>
+            <version>2.0</version>
+        </dependency>
+       
+        <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-archiver</artifactId>
             <version>2.4.4</version>

--- a/Portal/vip-application/pom.xml
+++ b/Portal/vip-application/pom.xml
@@ -131,6 +131,30 @@ knowledge of the CeCILL-B license and that you accept its terms.
         </dependency>
 
         <dependency>
+            <groupId>org.jivesoftware</groupId>
+            <artifactId>smack</artifactId>
+            <version>3.2.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>fr.insalyon.creatis.shiwapool</groupId>
+            <artifactId>shiwa-desktop-gui</artifactId>
+            <version>1.5.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>fr.insalyon.creatis.shiwapool</groupId>
+            <artifactId>shiwa-desktop-data</artifactId>
+            <version>1.5.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>fr.insalyon.creatis.shiwapool</groupId>
+            <artifactId>shiwa-pool-common</artifactId>
+            <version>0.9</version>
+        </dependency>
+
+        <dependency>
             <groupId>fr.insalyon.creatis.shiwapool</groupId>
             <artifactId>shiwa-pool-client</artifactId>
             <version>0.9</version>

--- a/Portal/vip-datamanagement/pom.xml
+++ b/Portal/vip-datamanagement/pom.xml
@@ -62,6 +62,12 @@ knowledge of the CeCILL-B license and that you accept its terms.
         </dependency>
         
         <dependency>
+            <groupId>fr.insalyon.creatis</groupId>
+            <artifactId>grida-common</artifactId>
+            <version>1.4</version>
+        </dependency>
+        
+        <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
             <version>1.2.2</version>

--- a/Portal/vip-portal/pom.xml
+++ b/Portal/vip-portal/pom.xml
@@ -138,6 +138,17 @@ knowledge of the CeCILL-B license and that you accept its terms.
             <artifactId>webservices-rt</artifactId>
             <version>2.3</version>
         </dependency>
+
+        <dependency>
+            <groupId>sun.jdk</groupId>
+            <artifactId>plugin</artifactId>
+            <version>1.8.0</version>
+            <!--
+            <scope>system</scope>
+            <systemPath>${java.home}/lib/plugin.jar</systemPath>
+            -->
+        </dependency>
+
     </dependencies>
     
     <build>

--- a/Portal/vip-query/pom.xml
+++ b/Portal/vip-query/pom.xml
@@ -82,6 +82,11 @@ knowledge of the CeCILL-B license and that you accept its terms.
     <dependencies>
         <dependency>
             <groupId>fr.insalyon.creatis</groupId>
+            <artifactId>grida-common</artifactId>
+            <version>1.4</version>
+        </dependency>
+        <dependency>
+            <groupId>fr.insalyon.creatis</groupId>
             <artifactId>vip-core</artifactId>
             <version>${vip.core.version}</version>
             <scope>provided</scope>


### PR DESCRIPTION
This PR adds a bunch of missing dependency definitions in pom.xml files

They were required to "mvn compile" in Portal subfolder