### PR TITLE
Move away from SSLv3 to TLS

### DIFF
--- a/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/proxy/ProxyClient.java
+++ b/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/proxy/ProxyClient.java
@@ -188,7 +188,7 @@ public class ProxyClient {
 
     private void connect() throws Exception {
 
-        SSLContext sc = SSLContext.getInstance("SSL");
+        SSLContext sc = SSLContext.getInstance("TLS");
         sc.init(new KeyManager[]{}, new TrustManager[]{new ProxyClient.MyTrustManager()}, new SecureRandom());
         SSLSocketFactory sf = sc.getSocketFactory();
 
@@ -196,7 +196,7 @@ public class ProxyClient {
                 Server.getInstance().getMyProxyHost(),
                 Server.getInstance().getMyProxyPort());
 
-        this.socket.setEnabledProtocols(new String[]{"SSLv3"});
+        this.socket.setEnabledProtocols(new String[]{"TLSv1.2"});
         this.socket.startHandshake();
         this.socketIn = new BufferedInputStream(this.socket.getInputStream());
         this.socketOut = new BufferedOutputStream(this.socket.getOutputStream());


### PR DESCRIPTION
- Following SSL V3.0 "Poodle" Vulnerability - CVE-2014-3566
  SSLv3 has been disabled by default in JDKs (8u31, 7u75, 6u91)
  See: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-3566
- Change MyProxy SSL socket settings to use TLS instead

Discovered as the following error message was logged:
javax.net.ssl.SSLHandshakeException: No appropriate protocol
(protocol is disabled or cipher suites are inappropriate)

Signed-off-by: Vincent Legoll <vincent.legoll@gmail.com>