### PR TITLE
Fix bug when email filtering lists are empty

### DIFF
--- a/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/ConfigurationBusiness.java
+++ b/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/ConfigurationBusiness.java
@@ -143,21 +143,25 @@ public class ConfigurationBusiness {
         message.append(user.getEmail());
         message.append(". List of undesired mail domains: ");
         for (String s : Server.getInstance().getUndesiredMailDomains()) {
-            message.append(" ");
-            message.append(s);
+            if (!s.trim().isEmpty()) {
+                message.append(" ");
+                message.append(s);
+            }
         }
         message.append(". ");
         message.append("List of undesired countries: ");
         for (String s : Server.getInstance().getUndesiredCountries()) {
-            message.append(" ");
-            message.append(s);
+            if (!s.trim().isEmpty()) {
+                message.append(" ");
+                message.append(s);
+            }
         }
         message.append(".");
         logger.info(message.toString());
 
         // Check if email domain is undesired
         for (String udm : Server.getInstance().getUndesiredMailDomains()) {
-            if (user.getEmail().endsWith(udm)) {
+            if (!udm.trim().isEmpty() && user.getEmail().endsWith(udm)) {
                 logger.info("Undesired Mail Domain for " + user.getEmail());
                 throw new BusinessException("Error");
             }
@@ -165,7 +169,7 @@ public class ConfigurationBusiness {
         
         // Check if country is undesired
         for (String udc : Server.getInstance().getUndesiredCountries()){
-            if(user.getCountryCode().toString().equals(udc)){
+            if (!udc.trim().isEmpty() && user.getCountryCode().toString().equals(udc)){
                 logger.info("Undesired country for " + user.getEmail());
                 throw new BusinessException("Error");
             }


### PR DESCRIPTION
- Undesired country & domain lists in config file can be empty. But the
  org.apache.commons.configuration.PropertiesConfiguration.getList() API
  returns a List<String> containing a single empty string in that case.
  So skip those "almost-empty" items.

Symptom, in vip.log:

ConfigurationBusiness:158 - Signing up email@domain.com. List of undesired mail domains:  . List of undesired countries:  .
ConfigurationBusiness:163 - Undesired Mail Domain for email@domain.com

Look at the empty "List of undesired mail domains"...

Signed-off-by: Vincent Legoll <vincent.legoll@gmail.com>