### PR TITLE
Fix undesired email domain handling

### DIFF
--- a/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/ConfigurationBusiness.java
+++ b/Portal/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/ConfigurationBusiness.java
@@ -157,7 +157,13 @@ public class ConfigurationBusiness {
 
         // Check if email domain is undesired
         for (String udm : Server.getInstance().getUndesiredMailDomains()) {
-            if (user.getEmail().endsWith(udm)) {
+            String[] useremail = user.getEmail().split("@");
+            if (useremail.length != 2) {
+                logger.info("User Mail address is incorrect : " + user.getEmail());
+                throw new BusinessException("Error");
+            }
+            // Only check against the domain part of the user's email address
+            if (useremail[1].endsWith(udm)) {
                 logger.info("Undesired Mail Domain for " + user.getEmail());
                 throw new BusinessException("Error");
             }


### PR DESCRIPTION
An undesired domain of, for example, "t.com" was matching
against "user@hit.com", which is counter-intuitive.

Signed-off-by: Vincent Legoll <vincent.legoll@gmail.com>