### PR TITLE
Seems markAsRead's onFailure() has been copied from MessageLayout.java

### DIFF
--- a/Portal/vip-social/src/main/java/fr/insalyon/creatis/vip/social/client/view/message/MessageViewerWindow.java
+++ b/Portal/vip-social/src/main/java/fr/insalyon/creatis/vip/social/client/view/message/MessageViewerWindow.java
@@ -141,7 +141,7 @@ public class MessageViewerWindow extends Window {
         AsyncCallback<Void> callback = new AsyncCallback<Void>() {
 
             public void onFailure(Throwable caught) {
-                Layout.getInstance().setWarningMessage("Unable to get list of messages:<br />" + caught.getMessage());
+                Layout.getInstance().setWarningMessage("Unable to mark message as read:<br />" + caught.getMessage());
             }
 
             public void onSuccess(Void result) {


### PR DESCRIPTION
The error message ought to be different to help debug problems

Signed-off-by: Vincent Legoll <vincent.legoll@gmail.com>