### PR TITLE
3023 bugfix get execution status

### DIFF
--- a/Portal/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/ExecutionBusiness.java
+++ b/Portal/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/ExecutionBusiness.java
@@ -122,7 +122,7 @@ public class ExecutionBusiness {
     public Execution getExecution(String executionId, boolean summarize) throws ApiException {
         try {
             // Get main execution object
-            Simulation s = workflowBusiness.getSimulation(executionId);
+            Simulation s = workflowBusiness.getSimulation(executionId, true); // check running execution for update
 
             // Return null if execution doesn't exist or is cleaned (cleaned status is not supported in Carmin)
             if (s == null || s.getStatus() == SimulationStatus.Cleaned) {

--- a/Portal/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowBusiness.java
+++ b/Portal/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowBusiness.java
@@ -74,12 +74,7 @@ import fr.insalyon.creatis.vip.datamanager.client.view.DataManagerException;
 import fr.insalyon.creatis.vip.datamanager.server.DataManagerUtil;
 import fr.insalyon.creatis.vip.datamanager.server.business.DataManagerBusiness;
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 import java.util.logging.Level;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -521,6 +516,17 @@ public class WorkflowBusiness {
      * @throws BusinessException
      */
     public Simulation getSimulation(String simulationID) throws BusinessException {
+        return getSimulation(simulationID, false);
+    }
+
+    /**
+     *
+     * @param simulationID
+     * @param refresh
+     * @return
+     * @throws BusinessException
+     */
+    public Simulation getSimulation(String simulationID, boolean refresh) throws BusinessException {
 
         Simulation simulation = null;
         try {
@@ -538,6 +544,9 @@ public class WorkflowBusiness {
                     workflow.getDescription(),
                     workflow.getStatus().name(),
                     workflow.getEngine());
+            if (refresh) {
+                checkRunningSimulations(Collections.singletonList(simulation));
+            }
 
         } catch (WorkflowsDBDAOException ex) {
             logger.error(ex);


### PR DESCRIPTION
When getting a single execution in the Carmin API, it is necessary to update this execution's status if it's running to be informed of its completion.