### PR TITLE
Gitattribute file : wrapper.vm eol=lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/Portal/vip-portal/src/main/resources/vm/wrapper.vm text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-/Portal/vip-portal/src/main/resources/vm/wrapper.vm text eol=lf
+*.vm text eol=lf


### PR DESCRIPTION
The .gitattributes file to give attributes to pathnames. For the time being, it concerns "wrapper.wm" file. It ensures that "wrapper.wm" file line endings are converted to LF in the repository.