### PR TITLE
Support for Bosh exec (Redmine #3147)

### DIFF
--- a/Portal/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/JSONUtil.java
+++ b/Portal/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/JSONUtil.java
@@ -83,7 +83,7 @@ public class JSONUtil {
         bi.setName(getPropertyAsString(input, "name"));
         bi.setType(getPropertyAsString(input, "type"));
         bi.setDescription(getPropertyAsString(input, "description", ""));
-        bi.setCommandLineKey(getPropertyAsString(input, "command-line-key"));
+        bi.setValueKey(getPropertyAsString(input, "value-key"));
         bi.setList(getPropertyAsBoolean(input, "list"));
         bi.setOptional(getPropertyAsBoolean(input, "optional"));
         bi.setCommandLineFlag(getPropertyAsString(input, "command-line-flag", ""));
@@ -99,7 +99,7 @@ public class JSONUtil {
         bof.setId(getPropertyAsString(outputFile, "id"));
         bof.setName(getPropertyAsString(outputFile, "name"));
         bof.setDescription(getPropertyAsString(outputFile, "description"));
-        bof.setCommandLineKey(getPropertyAsString(outputFile, "command-line-key"));
+        bof.setValueKey(getPropertyAsString(outputFile, "value-key"));
         bof.setPathTemplate(getPropertyAsString(outputFile, "path-template"));
         bof.setList(getPropertyAsBoolean(outputFile, "list"));
         bof.setOptional(getPropertyAsBoolean(outputFile, "optional"));

--- a/Portal/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/bean/BoutiquesInput.java
+++ b/Portal/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/bean/BoutiquesInput.java
@@ -43,7 +43,7 @@ public class BoutiquesInput implements IsSerializable {
     private String name;
     private String type;
     private String description;
-    private String commandLineKey;
+    private String valueKey;
     private boolean list;
     private boolean optional;
     private String commandLineFlag;
@@ -65,8 +65,8 @@ public class BoutiquesInput implements IsSerializable {
         return description;
     }
 
-    public String getCommandLineKey() {
-        return commandLineKey;
+    public String getValueKey() {
+        return valueKey;
     }
 
     public boolean isList() {
@@ -101,8 +101,8 @@ public class BoutiquesInput implements IsSerializable {
         this.description = description;
     }
 
-    public void setCommandLineKey(String commandLineKey) {
-        this.commandLineKey = commandLineKey;
+    public void setValueKey(String valueKey) {
+        this.valueKey = valueKey;
     }
 
     public void setList(boolean list) {

--- a/Portal/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/bean/BoutiquesOutputFile.java
+++ b/Portal/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/bean/BoutiquesOutputFile.java
@@ -42,7 +42,7 @@ public class BoutiquesOutputFile implements IsSerializable {
     private String id;
     private String name;
     private String description;
-    private String commandLineKey;
+    private String valueKey;
     private String pathTemplate;
     private boolean list;
     private boolean optional;
@@ -60,8 +60,8 @@ public class BoutiquesOutputFile implements IsSerializable {
         return description;
     }
 
-    public String getCommandLineKey() {
-        return commandLineKey;
+    public String getValueKey() {
+        return valueKey;
     }
 
     public String getPathTemplate() {
@@ -92,8 +92,8 @@ public class BoutiquesOutputFile implements IsSerializable {
         this.description = description;
     }
 
-    public void setCommandLineKey(String commandLineKey) {
-        this.commandLineKey = commandLineKey;
+    public void setValueKey(String valueKey) {
+        this.valueKey = valueKey;
     }
 
     public void setPathTemplate(String pathTemplate) {

--- a/Portal/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/bean/BoutiquesTool.java
+++ b/Portal/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/bean/BoutiquesTool.java
@@ -177,4 +177,8 @@ public class BoutiquesTool implements IsSerializable {
         return applicationLFN;
     }
 
+    public boolean hasNextInput(BoutiquesInput input) {
+        return inputs.lastIndexOf(input) < (inputs.size()-1) ? true : false;
+    }
+
 }

--- a/Portal/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/InputLayout.java
+++ b/Portal/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/InputLayout.java
@@ -68,8 +68,8 @@ public class InputLayout extends InputOutputLayout {
             generalLayout.setMembersMargin(membersMargin);
 
             HLayout commandLineLayout = new HLayout();
-            if (bi.getCommandLineKey() != null) {
-                commandLineLayout.addMember(new LocalTextField("Command-line key", false, false, bi.getCommandLineKey()));
+            if (bi.getValueKey() != null) {
+                commandLineLayout.addMember(new LocalTextField("Value key", false, false, bi.getValueKey()));
             }
             if (bi.getCommandLineFlag() != null && !bi.getCommandLineFlag().equals("")) {
                 commandLineLayout.addMember(new LocalTextField("Command-line flag", false, false, bi.getCommandLineFlag()));

--- a/Portal/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/OutputLayout.java
+++ b/Portal/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/OutputLayout.java
@@ -67,8 +67,8 @@ public class OutputLayout extends InputOutputLayout {
             generalLayout.setMembersMargin(membersMargin);
 
             HLayout commandLayout = new HLayout();
-            if (bof.getCommandLineKey() != null) {
-                commandLayout.addMember(new LocalTextField("Command-line key", false, false, bof.getCommandLineKey()));
+            if (bof.getValueKey() != null) {
+                commandLayout.addMember(new LocalTextField("Value key", false, false, bof.getValueKey()));
             }
             if (bof.getCommandLineFlag() != null && !bof.getCommandLineFlag().equals("")) {
                 commandLayout.addMember(new LocalTextField("Command-line Flag", false, false, bof.getCommandLineFlag()));

--- a/Portal/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/server/business/ApplicationImporterBusiness.java
+++ b/Portal/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/server/business/ApplicationImporterBusiness.java
@@ -143,9 +143,7 @@ public class ApplicationImporterBusiness {
             
             // Write application json descriptor
             String jsonFileName = Server.getInstance().getApplicationImporterFileRepository() + bt.getJsonLFN();
-            System.out.print(jsonFileName + "\n");
-            writeString(bt.getJsonFile(), jsonFileName);
-            uploadFile(jsonFileName, bt.getJsonLFN());
+            writeString(bt.getJsonFile(), jsonFileName);         
   
             String wrapperArchiveName;
             // Write files for each GASW and script file
@@ -156,6 +154,8 @@ public class ApplicationImporterBusiness {
 
                 ArrayList<File> dependencies = new ArrayList<File>();
                 dependencies.add(new File(wrapperFileName.get(e.getKey())));
+                //Add json file to archive so that it is downloaded on WN for Boutiques exec
+                dependencies.add(new File(jsonFileName));
                 TargzUtils.createTargz(dependencies, wrapperArchiveName);
 
                 // Transfer files
@@ -168,6 +168,8 @@ public class ApplicationImporterBusiness {
 
                 uploadFile(wrapperArchiveName, bt.getWrapperLFN() + ".tar.gz");
             }
+            //Upload the JSON file at the end, so that it is not deleted before adding it as dependency to wrapperArchiveName
+            uploadFile(jsonFileName, bt.getJsonLFN());
         
 // Register application
             registerApplicationVersion(bt.getName(), bt.getToolVersion(), user.getEmail(), bt.getGwendiaLFN());

--- a/Portal/vip-portal/src/main/resources/vm/gasw.vm
+++ b/Portal/vip-portal/src/main/resources/vm/gasw.vm
@@ -24,8 +24,8 @@
 #set ($i=1)
 #foreach($input in $tool.getInputs())
 #set ($i=$i+1)
-#if($input.getCommandLineKey()!="")
-#set ($value=$value.replace($input.getCommandLineKey(),"$na$i"))
+#if($input.getValueKey()!="")
+#set ($value=$value.replace($input.getValueKey(),"$na$i"))
 #end
 #end
       <template value="$dir1/$na1/$value"/>

--- a/Portal/vip-portal/src/main/resources/vm/wrapper.vm
+++ b/Portal/vip-portal/src/main/resources/vm/wrapper.vm
@@ -79,13 +79,22 @@ fi
 
 shift # first parameter is always results directory
 
+cat << JSONPARAMETERS  > input_param_file.json
+{
+JSONPARAMETERS
+
 while [[ $# > 0 ]]
 do
 key="$1"
 case $key in
     #foreach($input in $tool.getInputs())
 --$input.getId().toLowerCase())
-    $input.getId().toUpperCase()="$2"
+    $input.getId().toUpperCase()="$2" && \ 
+       #if($tool.hasNextInput($input))
+            echo "\"$input.getId()\" : \"$2\"," >> input_param_file.json
+       #else
+            echo "\"$input.getId()\" : \"$2\"" >> input_param_file.json
+       #end
     ;;
     #end
     #foreach($outputFile in $tool.getOutputFiles())
@@ -102,84 +111,16 @@ shift # past argument or value
 shift
 done
 
-#############################
-# Command-line construction #
-#############################
-
-BOUTIQUES_COMMAND_LINE='$tool.getCommandLine()'
-
-## Start with outputs so that input command line keys are replaced in path templates.
-#set($ob="{")
-#foreach($outputFile in $tool.getOutputFiles())
-## Replace command-line keys
-#if($outputFile.getCommandLineKey())
-	#if($outputFile.getCommandLineFlag() && $outputFile.getCommandLineFlag() != "")
-		#set($newValue="""$outputFile.getCommandLineFlag() $$outputFile.getId().toUpperCase()""")
-	#else
-		#set($newValue="""$$outputFile.getId().toUpperCase()""")
-	#end
-BOUTIQUES_COMMAND_LINE=$${ob}BOUTIQUES_COMMAND_LINE//'$outputFile.getCommandLineKey()'/$newValue}
-#end
-#end 
-
-#foreach($input in $tool.getInputs())
-  #if($input.isOptional())
-if [ "$$input.getId().toUpperCase()" != "no" ] && [ "$$input.getId().toUpperCase()" != "No_value_provided" ]
-then
-  # Optional input is active.
-  #end
-  #if($input.getType() != "Flag")
-	#if($input.getCommandLineFlag() && $input.getCommandLineFlag() != "")
-		#set($newValue="""$input.getCommandLineFlag() $$input.getId().toUpperCase()""")
-	#else
-		#set($newValue="""$$input.getId().toUpperCase()""")
-	#end
-    #if($input.getType() == "File" && $input.isOptional())
-  # Optional input is active and it is a file. The file needs to be downloaded (optional files are not handled by GASW).
-  downloadLFN $$input.getId().toUpperCase()
-  LOCAL_FILE_NAME=`basename $$input.getId().toUpperCase()`
-		#if($input.getCommandLineFlag() && $input.getCommandLineFlag() != "")
-			BOUTIQUES_COMMAND_LINE=$${ob}BOUTIQUES_COMMAND_LINE//'$input.getCommandLineKey()'/"$input.getCommandLineFlag() ${LOCAL_FILE_NAME}"}
-		#else
-			BOUTIQUES_COMMAND_LINE=$${ob}BOUTIQUES_COMMAND_LINE//'$input.getCommandLineKey()'/"${LOCAL_FILE_NAME}"}
-		#end
-    #else
-  BOUTIQUES_COMMAND_LINE=$${ob}BOUTIQUES_COMMAND_LINE//'$input.getCommandLineKey()'/$newValue}
-    #end
-  #else
-if [ "$$input.getId().toUpperCase()" = "true" ]
-then
-  # flag is set: replace command-line key by flag value
-  BOUTIQUES_COMMAND_LINE=$${ob}BOUTIQUES_COMMAND_LINE//'$input.getCommandLineKey()'/$input.getCommandLineFlag()}
-else
-  # flag is unset: remove command-line key from command-line. 
-  BOUTIQUES_COMMAND_LINE=$${ob}BOUTIQUES_COMMAND_LINE//'$input.getCommandLineKey()'/""}
-fi
-#end
-#if($input.isOptional())
-else
-  # Optional input is not active: remove command-line key from command-line. 
-  BOUTIQUES_COMMAND_LINE=$${ob}BOUTIQUES_COMMAND_LINE//'$input.getCommandLineKey()'/""}
-fi
-#end
-#end
+cat << JSONPARAMETERS  >> input_param_file.json
+}
+JSONPARAMETERS
 
 ##########################
 # Command-line execution #
 ##########################
 
-#if($tool.getDockerImage())
-cat << DOCKERJOB > .dockerjob.sh
-#!/bin/bash -l
-${BOUTIQUES_COMMAND_LINE}
-DOCKERJOB
-
-chmod 755 .dockerjob.sh
-docker pull $tool.getDockerImage()
-docker run --rm -v $PWD:/gasw-execution-dir -v $PWD/../cache:$PWD/../cache -w /gasw-execution-dir -u `id -u`:`id -g` $tool.getDockerImage()  ./.dockerjob.sh 
-#else
-${BOUTIQUES_COMMAND_LINE}
-#end
+pip install boutiques --user
+$HOME/.local/bin/bosh exec launch ./$tool.getName().json ./input_param_file.json -v $PWD:/gasw-execution-dir $PWD/../cache:$PWD/../cache
 
 if [ $? != 0 ]
 then

--- a/Portal/vip-portal/src/main/resources/vm/wrapper.vm
+++ b/Portal/vip-portal/src/main/resources/vm/wrapper.vm
@@ -19,23 +19,6 @@ function error {
   echo [ ERROR - $D ] $* >&2
 }
 
-function checkBosh {
-  export PATH=$PATH:$HOME/.local/bin
-  BOSH=`which bosh`
-  if [ -z "$BOSH" ]
-    then
-      info "Installing Boutiques locally"
-      pip install boutiques --user    
-      if [ $? != 0 ]
-      then
-        error "pip install boutiques failed, exiting"
-        return 1
-      fi
-    else
-      info "Bosh exists in $BOSH, nothing to do"
-  fi
-}
-
 function downloadLFN {
 
   local LFN=$1
@@ -129,15 +112,17 @@ JSONPARAMETERS
 
 TOOLNAME="$tool.getName()"
 JSONFILE="${TOOLNAME}.json"
+export PATH=$PATH:$HOME/.local/bin
 
-checkBosh
+#check bosh and install it if needed
+bosh create foo.sh || pip install boutiques --user || error "pip install boutiques failed"
 bosh exec launch $JSONFILE input_param_file.json -v $PWD/../cache:$PWD/../cache
 
 if [ $? != 0 ]
 then
-    echo "$tool.name execution failed!"
+    error "$tool.name execution failed!"
     exit 1
 fi
 
-echo "Execution of $tool.getName() completed."
+info "Execution of $tool.getName() completed."
 

--- a/Portal/vip-portal/src/main/resources/vm/wrapper.vm
+++ b/Portal/vip-portal/src/main/resources/vm/wrapper.vm
@@ -26,6 +26,11 @@ function checkBosh {
     then
       info "Installing Boutiques locally"
       pip install boutiques --user    
+      if [ $? != 0 ]
+      then
+        error "pip install boutiques failed, exiting"
+        return 1
+      fi
     else
       info "Bosh exists in $BOSH, nothing to do"
   fi
@@ -108,6 +113,7 @@ case $key in
        #end
     ;;
     #end
+*) # unknown option
 esac
 shift # past argument or value
 shift
@@ -125,7 +131,7 @@ TOOLNAME="$tool.getName()"
 JSONFILE="${TOOLNAME}.json"
 
 checkBosh
-bosh exec launch $JSONFILE input_param_file.json -v $PWD:/gasw-execution-dir $PWD/../cache:$PWD/../cache
+bosh exec launch $JSONFILE input_param_file.json -v $PWD/../cache:$PWD/../cache
 
 if [ $? != 0 ]
 then

--- a/Portal/vip-portal/src/main/resources/vm/wrapper.vm
+++ b/Portal/vip-portal/src/main/resources/vm/wrapper.vm
@@ -19,6 +19,18 @@ function error {
   echo [ ERROR - $D ] $* >&2
 }
 
+function checkBosh {
+  export PATH=$PATH:$HOME/.local/bin
+  BOSH=`which bosh`
+  if [ -z "$BOSH" ]
+    then
+      info "Installing Boutiques locally"
+      pip install boutiques --user    
+    else
+      info "Bosh exists in $BOSH, nothing to do"
+  fi
+}
+
 function downloadLFN {
 
   local LFN=$1
@@ -89,7 +101,6 @@ key="$1"
 case $key in
     #foreach($input in $tool.getInputs())
 --$input.getId().toLowerCase())
-    $input.getId().toUpperCase()="$2" && \ 
        #if($tool.hasNextInput($input))
             echo "\"$input.getId()\" : \"$2\"," >> input_param_file.json
        #else
@@ -97,15 +108,6 @@ case $key in
        #end
     ;;
     #end
-    #foreach($outputFile in $tool.getOutputFiles())
---$outputFile.getId().toLowerCase())
-    $outputFile.getId().toUpperCase()="$2"
-    ;;
-    #end
-*) # unknown option
-    echo "Unknown option: $1"
-    exit 1
-    ;;
 esac
 shift # past argument or value
 shift
@@ -119,8 +121,11 @@ JSONPARAMETERS
 # Command-line execution #
 ##########################
 
-pip install boutiques --user
-$HOME/.local/bin/bosh exec launch ./$tool.getName().json ./input_param_file.json -v $PWD:/gasw-execution-dir $PWD/../cache:$PWD/../cache
+TOOLNAME="$tool.getName()"
+JSONFILE="${TOOLNAME}.json"
+
+checkBosh
+bosh exec launch $JSONFILE input_param_file.json -v $PWD:/gasw-execution-dir $PWD/../cache:$PWD/../cache
 
 if [ $? != 0 ]
 then


### PR DESCRIPTION
Replaces the previous Boutiques command line with an input_param_file.json, which is passed to bosh exec. 
Integrates some of the developements of PR #141 and #142, which become obsolete (will be closed without merging).

Important warnings:
- careful with Python 2.6 compatibility on EGI sites (currently working on local VMs using pip version 9 and jsonschema 2.5.1)
- only applies to newly imported applications
