### PR TITLE
Update the gwiendia template to support generic URIs

### DIFF
--- a/Portal/vip-portal/src/main/resources/vm/gwendia.vm
+++ b/Portal/vip-portal/src/main/resources/vm/gwendia.vm
@@ -35,12 +35,15 @@
       <in name="dir" type="URI" depth="0" />
       <out name="result" type="string" depth="0" />
       <beanshell>/*----------Beginning of Beanshell------------*/
-                        import java.text.DateFormat;
-                        import java.text.SimpleDateFormat;
-                        import java.util.Date;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
-DateFormat dateFormat = new SimpleDateFormat("dd-MM-yyyy_HH:mm:ss");
-String result = dir.toString()+"/"+(dateFormat.format(System.currentTimeMillis()));
+String result = dir.toString();
+if ( result.startsWith("/") || result.startsWith("lfn:") ) {
+  DateFormat dateFormat = new SimpleDateFormat("dd-MM-yyyy_HH:mm:ss");
+  result = result + "/" + (dateFormat.format(System.currentTimeMillis()));
+}
 /*------------End of Beanshell------------*/
       </beanshell>
     </processor>


### PR DESCRIPTION
Only append a directory with timestamp on results-directory when it is a LFN

This is done in the gwiendia file generated on an automatic import.
With the new URI support in gasw, we only keep this behavior when
the "results-directory" parameter is a LFN.