### PR TITLE
chore: don't include sources in modules jar file.

### DIFF
--- a/Portal/vip-application-importer/pom.xml
+++ b/Portal/vip-application-importer/pom.xml
@@ -116,10 +116,25 @@ knowledge of the CeCILL-B license and that you accept its terms.
             <resource>
                 <directory>src/main/java</directory>
                 <includes>
-                    <include>**/*.java</include>
                     <include>**/*.xml</include>
                 </includes>
             </resource>
         </resources>
+
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
     </build>
 </project>

--- a/Portal/vip-application/pom.xml
+++ b/Portal/vip-application/pom.xml
@@ -173,17 +173,33 @@ knowledge of the CeCILL-B license and that you accept its terms.
         </dependency>
 
     </dependencies>
+
     <build>
         <finalName>vip-application</finalName>
         <resources>
             <resource>
                 <directory>src/main/java</directory>
                 <includes>
-                    <include>**/*.java</include>
                     <include>**/*.xml</include>
                 </includes>
             </resource>
         </resources>
+
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
     </build>
 
     <repositories>

--- a/Portal/vip-core/pom.xml
+++ b/Portal/vip-core/pom.xml
@@ -234,13 +234,13 @@ knowledge of the CeCILL-B license and that you accept its terms.
             <version>12.0p</version>
         </dependency>
     </dependencies>
+
     <build>
         <finalName>vip-core</finalName>
         <resources>
             <resource>
                 <directory>src/main/java</directory>
                 <includes>
-                    <include>**/*.java</include>
                     <include>**/*.xml</include>
                 </includes>
             </resource>
@@ -248,6 +248,22 @@ knowledge of the CeCILL-B license and that you accept its terms.
                 <directory>src/main/resources</directory>
             </resource>
         </resources>
+
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
     </build>
 
     <repositories>

--- a/Portal/vip-datamanagement/pom.xml
+++ b/Portal/vip-datamanagement/pom.xml
@@ -70,14 +70,30 @@ knowledge of the CeCILL-B license and that you accept its terms.
     </dependencies>
     <build>
         <finalName>vip-datamanager</finalName>
+
         <resources>
             <resource>
                 <directory>src/main/java</directory>
                 <includes>
-                    <include>**/*.java</include>
                     <include>**/*.xml</include>
                 </includes>
             </resource>
         </resources>
+
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
     </build>
 </project>

--- a/Portal/vip-docs/pom.xml
+++ b/Portal/vip-docs/pom.xml
@@ -64,14 +64,30 @@ knowledge of the CeCILL-B license and that you accept its terms.
     </dependencies>
     <build>
         <finalName>vip-docs</finalName>
+
         <resources>
             <resource>
                 <directory>src/main/java</directory>
                 <includes>
-                    <include>**/*.java</include>
                     <include>**/*.xml</include>
                 </includes>
             </resource>
         </resources>
+
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
     </build>
 </project>

--- a/Portal/vip-gatelab/pom.xml
+++ b/Portal/vip-gatelab/pom.xml
@@ -78,14 +78,30 @@ knowledge of the CeCILL-B license and that you accept its terms.
     </dependencies>
     <build>
         <finalName>vip-gatelab</finalName>
+
         <resources>
             <resource>
                 <directory>src/main/java</directory>
                 <includes>
-                    <include>**/*.java</include>
                     <include>**/*.xml</include>
                 </includes>
             </resource>
         </resources>
+
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
     </build>
 </project>

--- a/Portal/vip-portal/pom.xml
+++ b/Portal/vip-portal/pom.xml
@@ -74,11 +74,27 @@ knowledge of the CeCILL-B license and that you accept its terms.
             <artifactId>vip-core</artifactId>
             <version>${vip.core.version}</version>
         </dependency>
+        <dependency>
+          <groupId>fr.insalyon.creatis</groupId>
+          <artifactId>vip-core</artifactId>
+          <type>jar</type>
+          <version>${vip.core.version}</version>
+          <classifier>sources</classifier>
+          <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>fr.insalyon.creatis</groupId>
             <artifactId>vip-docs</artifactId>
             <version>${vip.docs.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>fr.insalyon.creatis</groupId>
+          <artifactId>vip-docs</artifactId>
+          <type>jar</type>
+          <version>${vip.docs.version}</version>
+          <classifier>sources</classifier>
+          <scope>provided</scope>
         </dependency>
 
          <dependency>
@@ -86,11 +102,27 @@ knowledge of the CeCILL-B license and that you accept its terms.
             <artifactId>vip-application-importer</artifactId>
             <version>${vip.application-importer.version}</version>
         </dependency>
+        <dependency>
+          <groupId>fr.insalyon.creatis</groupId>
+          <artifactId>vip-application-importer</artifactId>
+          <type>jar</type>
+          <version>${vip.application-importer.version}</version>
+          <classifier>sources</classifier>
+          <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>fr.insalyon.creatis</groupId>
             <artifactId>vip-datamanager</artifactId>
             <version>${vip.datamanager.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>fr.insalyon.creatis</groupId>
+          <artifactId>vip-datamanager</artifactId>
+          <type>jar</type>
+          <version>${vip.datamanager.version}</version>
+          <classifier>sources</classifier>
+          <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -98,17 +130,41 @@ knowledge of the CeCILL-B license and that you accept its terms.
             <artifactId>vip-application</artifactId>
             <version>${vip.application.version}</version>
         </dependency>
+        <dependency>
+          <groupId>fr.insalyon.creatis</groupId>
+          <artifactId>vip-application</artifactId>
+          <type>jar</type>
+          <version>${vip.application.version}</version>
+          <classifier>sources</classifier>
+          <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>fr.insalyon.creatis</groupId>
             <artifactId>vip-gatelab</artifactId>
             <version>${vip.gatelab.version}</version>
         </dependency>
+        <dependency>
+          <groupId>fr.insalyon.creatis</groupId>
+          <artifactId>vip-gatelab</artifactId>
+          <type>jar</type>
+          <version>${vip.gatelab.version}</version>
+          <classifier>sources</classifier>
+          <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>fr.insalyon.creatis</groupId>
             <artifactId>vip-social</artifactId>
             <version>${vip.social.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>fr.insalyon.creatis</groupId>
+          <artifactId>vip-social</artifactId>
+          <type>jar</type>
+          <version>${vip.social.version}</version>
+          <classifier>sources</classifier>
+          <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/Portal/vip-social/pom.xml
+++ b/Portal/vip-social/pom.xml
@@ -71,7 +71,6 @@ knowledge of the CeCILL-B license and that you accept its terms.
             <resource>
                 <directory>src/main/java</directory>
                 <includes>
-                    <include>**/*.java</include>
                     <include>**/*.xml</include>
                     <include>**/*.txt</include>
                     <include>**/*.png</include>
@@ -82,6 +81,21 @@ knowledge of the CeCILL-B license and that you accept its terms.
             </resource>
         </resources>
 
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
     </build>
 
 </project>


### PR DESCRIPTION
Implements issue #192:
- put the sources in an another jar.  The sources are needed by the
  gwt java to javascript compiler.
- use the new source jars as dependencies in the portal project.
- sources jars are already excluded from the generated war.