### PR TITLE
Configurable tags for app import (issues #226 and #229)

### DIFF
--- a/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/rpc/ApplicationImporterService.java
+++ b/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/rpc/ApplicationImporterService.java
@@ -37,6 +37,7 @@ import com.google.gwt.user.client.rpc.RemoteService;
 import com.google.gwt.user.client.rpc.ServiceDefTarget;
 import fr.insalyon.creatis.vip.applicationimporter.client.bean.BoutiquesTool;
 import java.util.HashMap;
+import java.util.List;
 
 public interface ApplicationImporterService extends RemoteService {
 
@@ -55,4 +56,9 @@ public interface ApplicationImporterService extends RemoteService {
     String readAndValidateBoutiquesFile(String fileLFN) throws ApplicationImporterException;
 
     void createApplication(BoutiquesTool bt, String type, String tag, HashMap<String, BoutiquesTool> bts, boolean isRunOnGrid, boolean overwriteVersion, boolean challenge) throws ApplicationImporterException;
+   
+    String getApplicationImporterRootFolder() throws ApplicationImporterException;
+    
+    List<String> getApplicationImporterRequirements() throws ApplicationImporterException;
+    
 }

--- a/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/rpc/ApplicationImporterServiceAsync.java
+++ b/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/rpc/ApplicationImporterServiceAsync.java
@@ -34,10 +34,16 @@ package fr.insalyon.creatis.vip.applicationimporter.client.rpc;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import fr.insalyon.creatis.vip.applicationimporter.client.bean.BoutiquesTool;
 import java.util.HashMap;
+import java.util.List;
 
 public interface ApplicationImporterServiceAsync {
 
     public void readAndValidateBoutiquesFile(String fileLFN, AsyncCallback<String> callback);
 
     public void createApplication(BoutiquesTool bt, String type, String tag, HashMap<String, BoutiquesTool> bts, boolean isRunOnGrid, boolean overwriteVersion, boolean challenge, AsyncCallback<Void> callback);
+    
+    public void getApplicationImporterRootFolder(AsyncCallback<String> asyncCallback);
+    
+    public void getApplicationImporterRequirements(AsyncCallback<List<String>>  asyncCallback);
+
 }

--- a/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/VIPLayout.java
+++ b/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/VIPLayout.java
@@ -45,6 +45,7 @@ import fr.insalyon.creatis.vip.core.client.view.util.FieldUtil;
 import fr.insalyon.creatis.vip.datamanager.client.view.ValidatorUtil;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 public class VIPLayout extends AbstractFormLayout {
 
@@ -189,7 +190,7 @@ public class VIPLayout extends AbstractFormLayout {
                     result.add("None");
                 }
                 
-                LinkedHashMap<String, String> requirementsValues = new LinkedHashMap<String, String>();
+                Map<String, String> requirementsValues = new LinkedHashMap<>();
                 for (String requirement : result) {
                     requirementsValues.put(requirement, requirement);
                 }               

--- a/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/VIPLayout.java
+++ b/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/VIPLayout.java
@@ -176,8 +176,6 @@ public class VIPLayout extends AbstractFormLayout {
         tagsCb.setTitle("<b>Dirac tag</b>");
         tagsCb.setType("comboBox");
 
-        //tagsCb.setValueMap("None", "diracTag:nvidiaGPU");
-        
         final AsyncCallback<List<String>> callback = new AsyncCallback<List<String>>() {
             @Override
             public void onFailure(Throwable caught) {

--- a/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/VIPLayout.java
+++ b/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/VIPLayout.java
@@ -42,6 +42,7 @@ import fr.insalyon.creatis.vip.applicationimporter.client.view.Constants;
 import fr.insalyon.creatis.vip.core.client.view.common.AbstractFormLayout;
 import fr.insalyon.creatis.vip.core.client.view.layout.Layout;
 import fr.insalyon.creatis.vip.core.client.view.util.FieldUtil;
+import fr.insalyon.creatis.vip.datamanager.client.view.ValidatorUtil;
 import java.util.LinkedHashMap;
 import java.util.List;
 
@@ -121,8 +122,12 @@ public class VIPLayout extends AbstractFormLayout {
 
             @Override
             public void onSuccess(String result) {
-                //TODO: check access rights and point to Home if needed
-                applicationLocation.setValue(result);
+                if (ValidatorUtil.validateRootPath(result, "create a folder in")
+                        && ValidatorUtil.validateUserLevel(result, "create a folder in")) {
+                    applicationLocation.setValue(result);
+                }else{
+                    applicationLocation.setValue("/vip/Home");
+                }       
             }
         };
         ApplicationImporterService.Util.getInstance().getApplicationImporterRootFolder(callback);
@@ -171,7 +176,7 @@ public class VIPLayout extends AbstractFormLayout {
         tagsCb.setTitle("<b>Dirac tag</b>");
         tagsCb.setType("comboBox");
 
-        tagsCb.setValueMap("None", "diracTag:nvidiaGPU");
+        //tagsCb.setValueMap("None", "diracTag:nvidiaGPU");
         
         final AsyncCallback<List<String>> callback = new AsyncCallback<List<String>>() {
             @Override
@@ -185,8 +190,13 @@ public class VIPLayout extends AbstractFormLayout {
                 if(!result.contains("None")){
                     result.add("None");
                 }
-                //TODO : check if toString gives the right format for setValueMap
-                tagsCb.setValueMap(result.toString());
+                
+                LinkedHashMap<String, String> requirementsValues = new LinkedHashMap<String, String>();
+                for (String requirement : result) {
+                    requirementsValues.put(requirement, requirement);
+                }               
+                tagsCb.setValueMap(requirementsValues);
+                
             }
         };
         ApplicationImporterService.Util.getInstance().getApplicationImporterRequirements(callback);

--- a/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/server/rpc/ApplicationImporterServiceImpl.java
+++ b/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/server/rpc/ApplicationImporterServiceImpl.java
@@ -38,10 +38,12 @@ import fr.insalyon.creatis.vip.applicationimporter.server.business.ApplicationIm
 import fr.insalyon.creatis.vip.core.client.view.CoreException;
 import fr.insalyon.creatis.vip.core.server.business.BusinessException;
 import fr.insalyon.creatis.vip.core.server.dao.mysql.PlatformConnection;
+import fr.insalyon.creatis.vip.core.server.business.Server;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashMap;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,5 +79,15 @@ public class ApplicationImporterServiceImpl extends fr.insalyon.creatis.vip.core
             logger.error("Error handling a connection", ex);
             throw new ApplicationImporterException(ex);
         }
+    }
+
+    @Override
+    public String getApplicationImporterRootFolder() throws ApplicationImporterException {
+        return Server.getInstance().getApplicationImporterRootFolder();
+    }
+
+    @Override
+    public List<String> getApplicationImporterRequirements() throws ApplicationImporterException {
+        return Server.getInstance().getApplicationImporterRequirements();        
     }
 }

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/monitor/SimulationsToolStrip.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/monitor/SimulationsToolStrip.java
@@ -137,7 +137,7 @@ public class SimulationsToolStrip extends ToolStrip {
         if (CoreModule.user.isSystemAdministrator()) {
             this.addSeparator();
             // Purge Executions
-            this.addButton(WidgetUtil.getToolStripButton("Purge Executionss",
+            this.addButton(WidgetUtil.getToolStripButton("Purge Executions",
                     CoreConstants.ICON_CLEAR, null, new ClickHandler() {
                 @Override
                 public void onClick(ClickEvent event) {

--- a/vip-core/src/main/java/fr/insalyon/creatis/vip/core/client/view/CoreConstants.java
+++ b/vip-core/src/main/java/fr/insalyon/creatis/vip/core/client/view/CoreConstants.java
@@ -185,6 +185,8 @@ public class CoreConstants implements IsSerializable {
     public static String APP_CLASS = "boutiques.application.class";
     public static String APPLICATION_FILES_REPOSITORY = "boutiques.upload.repository";
     public static String APP_DELETE_FILES_AFTER_UPLOAD = "boutiques.upload.deleteFile";
+    public static String APP_IMPORTER_ROOT_FOLDER = "boutiques.application.rootFolder";
+    public static String APP_REQUIREMENTS = "boutiques.application.requirements";
     //Publiction
     public static final String  PUB_MONTHS_UPDATES = "last.publication.update";
     //Zenodo publication

--- a/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/Server.java
+++ b/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/Server.java
@@ -130,6 +130,8 @@ public class Server {
     // Application importer
     private String applicationImporterFileRepository;
     private String deleteFilesAfterUpload;
+    private String applicationImporterRootFolder;
+    private List<String> applicationImporterRequirements;
     //Publication
     private int numberMonthsToTestLastPublicationUpdates;
     //Zenodo publication
@@ -245,6 +247,9 @@ public class Server {
             //Applicatoin importer
             applicationImporterFileRepository = config.getString(CoreConstants.APPLICATION_FILES_REPOSITORY, "/tmp/boutiques-cache");
             deleteFilesAfterUpload = config.getString(CoreConstants.APP_DELETE_FILES_AFTER_UPLOAD, "yes");
+            applicationImporterRootFolder = config.getString(CoreConstants.APP_IMPORTER_ROOT_FOLDER, "/biomed/user/c/creatis/vip/data/groups/Applications");
+            List<String> listApplicationImporterRequirements = new ArrayList<>();
+            applicationImporterRequirements = config.getList(CoreConstants.APP_REQUIREMENTS, listApplicationImporterRequirements);
 
             //Publication
             numberMonthsToTestLastPublicationUpdates = config.getInt(CoreConstants.PUB_MONTHS_UPDATES, 6);
@@ -306,6 +311,8 @@ public class Server {
 
             config.setProperty(CoreConstants.APPLICATION_FILES_REPOSITORY, applicationImporterFileRepository);
             config.setProperty(CoreConstants.APP_DELETE_FILES_AFTER_UPLOAD, deleteFilesAfterUpload);
+            config.setProperty(CoreConstants.APP_IMPORTER_ROOT_FOLDER, applicationImporterRootFolder);
+            config.setProperty(CoreConstants.APP_REQUIREMENTS, applicationImporterRequirements);
             config.setProperty(CoreConstants.APPLET_GATELAB_CLASSES, appletGateLabClasses);
             config.setProperty(CoreConstants.APPLET_GATELABTEST_CLASSES, appletGateLabTestClasses);
             config.setProperty(CoreConstants.UNDESIRED_MAIL_DOMAINS, undesiredMailDomains);
@@ -538,6 +545,14 @@ public class Server {
 
     public String getApplicationImporterFileRepository() {
         return applicationImporterFileRepository;
+    }
+    
+    public String getApplicationImporterRootFolder() {
+        return applicationImporterRootFolder;
+    }
+        
+    public List<String> getApplicationImporterRequirements() {
+        return applicationImporterRequirements;
     }
 
     public String getDeleteFilesAfterUpload() {

--- a/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/Server.java
+++ b/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/Server.java
@@ -248,8 +248,7 @@ public class Server {
             applicationImporterFileRepository = config.getString(CoreConstants.APPLICATION_FILES_REPOSITORY, "/tmp/boutiques-cache");
             deleteFilesAfterUpload = config.getString(CoreConstants.APP_DELETE_FILES_AFTER_UPLOAD, "yes");
             applicationImporterRootFolder = config.getString(CoreConstants.APP_IMPORTER_ROOT_FOLDER, "/biomed/user/c/creatis/vip/data/groups/Applications");
-            List<String> listApplicationImporterRequirements = new ArrayList<>();
-            applicationImporterRequirements = config.getList(CoreConstants.APP_REQUIREMENTS, listApplicationImporterRequirements);
+            applicationImporterRequirements = config.getList(CoreConstants.APP_REQUIREMENTS, new ArrayList<>());
 
             //Publication
             numberMonthsToTestLastPublicationUpdates = config.getInt(CoreConstants.PUB_MONTHS_UPDATES, 6);


### PR DESCRIPTION
Improvements in application importer allowing to:
- configure a list of possible application requirements (i.e., dirac tags) in the VIP config file instead of hardcoding them;
- configure a default root path for the import of applications, so that they are all in the same place by default. 

issues #226 and #229