### PR TITLE
Restrict characters in api

### DIFF
--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/CarminProperties.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/CarminProperties.java
@@ -66,4 +66,5 @@ public interface CarminProperties {
     // CARMIN PROCESSING
 
     String API_PIPELINE_WHITE_LIST = "carmin.processing.pipelines.whitelist";
+    String ADDITIONNAL_INPUT_VALID_CHARS = "\\[\\]"; // will be use in regex, so brackets must be escaped
 }

--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/DataApiBusiness.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/DataApiBusiness.java
@@ -177,13 +177,14 @@ public class DataApiBusiness {
         // TODO : check if it already exists
         // TODO : support archive upload
         String uploadDirectory = DataManagerUtil.getUploadRootDirectory(false);
-        // TODO : normalize file name to avoid weird characters
-        String fileName = Paths.get(lfcPath).getFileName().toString();
+        // get file name and clean it as in an upload
+        String fileName = DataManagerUtil.getCleanFilename(
+                Paths.get(lfcPath).getFileName().toString() );
         String localPath = uploadDirectory + fileName;
         logger.debug("storing upload file in :" + localPath);
         boolean isFileEmpty = saveInputStreamToFile(is, localPath);
         if (isFileEmpty) {
-            logger.info("no content in upload, creating dir : " + lfcPath);
+            logger.info("no content in upload, creating dir : " + parentLfcPath + "/" + fileName);
             baseMkdir(parentLfcPath, fileName, connection);
         } else {
             String opId = baseUploadFile(localPath, parentLfcPath, connection);
@@ -212,8 +213,9 @@ public class DataApiBusiness {
         // TODO : check if it already exists
         // TODO : support archive upload
         String uploadDirectory = DataManagerUtil.getUploadRootDirectory(false);
-        // TODO : normalize file name to avoid weird characters
-        String fileName = Paths.get(lfcPath).getFileName().toString();
+        // get file name and clean it as in an upload
+        String fileName = DataManagerUtil.getCleanFilename(
+                Paths.get(lfcPath).getFileName().toString() );
         String localPath = uploadDirectory + fileName;
         logger.debug("storing upload file in :" + localPath);
         writeFileFromBase64(uploadData.getBase64Content(), localPath);
@@ -237,7 +239,10 @@ public class DataApiBusiness {
             logger.error("Trying do create an existing directory : {}", path);
             throw new ApiException("Mkdir error");
         }
-        baseMkdir(parentLfcPath, javaPath.getFileName().toString(), connection);
+        // get dir name and clean it as in an upload
+        String dirName = DataManagerUtil.getCleanFilename(
+                javaPath.getFileName().toString() );
+        baseMkdir(parentLfcPath, dirName, connection);
         PathProperties newPathProperties = new PathProperties();
         newPathProperties.setPath(path);
         newPathProperties.setIsDirectory(true);

--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/rest/controller/data/DataController.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/rest/controller/data/DataController.java
@@ -42,6 +42,7 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.*;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.*;
@@ -222,11 +223,17 @@ public class DataController {
         return SecurityContextHolder.getContext().getAuthentication().getName();
     }
 
-    private static String extractWildcardPath(HttpServletRequest request) {
-        String prefixToSearch = "/rest/path/"; // TODO : parametize that
-        int index = request.getRequestURI().indexOf(prefixToSearch);
-        // "-1" at the end to keep the beginning slash
-        return request.getRequestURI().substring(index + prefixToSearch.length() - 1);
+    private String extractWildcardPath(HttpServletRequest request) throws ApiException {
+        try {
+            String prefixToSearch = "/rest/path/"; // TODO : parametize that
+            String decodedUri = UriUtils.decode(request.getRequestURI(), "UTF-8");
+            int index = decodedUri.indexOf(prefixToSearch);
+            // "-1" at the end to keep the beginning slash
+            return decodedUri.substring(index + prefixToSearch.length() - 1);
+        } catch (UnsupportedEncodingException e) {
+            logger.error("Error decoding uri {}", request.getRequestURI(), e);
+            throw new ApiException(e);
+        }
     }
 }
 

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/ApplicationConstants.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/ApplicationConstants.java
@@ -119,6 +119,8 @@ public class ApplicationConstants {
     public static final String SESSION_CLASSES = "vip-classes";
     public static final String SEPARATOR_INPUT = "##";
     public static final String SEPARATOR_LIST = "@@";
+    public static final String INPUT_VALID_CHARS = "0-9.,A-Za-z-+@/_(): ";
+    public static final String EXEC_NAME_VALID_CHARS = "0-9A-Za-z-_ ";
 
     public static String getLaunchTabID(String applicationName) {
         return "launch_"

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/launch/LaunchFormLayout.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/launch/LaunchFormLayout.java
@@ -88,8 +88,10 @@ public class LaunchFormLayout extends AbstractFormLayout {
         });
         this.addMember(docLabel);
 
-        simulationNameItem = FieldUtil.getTextItem(400, "[0-9A-Za-z-_ ]");
-        simulationNameItem.setValidators(ValidatorUtil.getStringValidator());
+        simulationNameItem = FieldUtil.getTextItem(400,
+                "[" + ApplicationConstants.EXEC_NAME_VALID_CHARS + "]");
+        simulationNameItem.setValidators(ValidatorUtil.getStringValidator(
+                "^([" + ApplicationConstants.EXEC_NAME_VALID_CHARS + "])+$"));
         simulationNameItem.setEditPendingCSSText("padding-left: 30px");
 
         if (executionNamePadding) { // To align horizontaly "Execution name" and the text field on the others comboBoxes (inputs comboBoxes) of the screen

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/launch/ListHLayout.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/launch/ListHLayout.java
@@ -77,9 +77,11 @@ public class ListHLayout extends HLayout {
         this.instance = this;
         this.setMembersMargin(3);
 
-        listItem = FieldUtil.getTextItem(400, false, "", "[0-9.,A-Za-z-+/_(){}: ]");
+        listItem = FieldUtil.getTextItem(400, false, "",
+                "[" + ApplicationConstants.INPUT_VALID_CHARS + "]");
         listItem.setValue(value);
-        listItem.setValidators(ValidatorUtil.getStringValidator());
+        listItem.setValidators(ValidatorUtil.getStringValidator(
+                "^([" + ApplicationConstants.INPUT_VALID_CHARS + "])+$"));
 
         if (optional) {
             listItem.setRequiredMessage(ApplicationConstants.INPUT_WITHOUT_VALUE_REQUIRED_MESSAGE);

--- a/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/ConfigurationBusiness.java
+++ b/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/ConfigurationBusiness.java
@@ -168,7 +168,8 @@ public class ConfigurationBusiness {
             user.setPassword(MD5.get(user.getPassword()));
             String folder = user.getFirstName().replaceAll(" ", "_").toLowerCase() + "_"
                             + user.getLastName().replaceAll(" ", "_").toLowerCase();
-            folder = Normalizer.normalize(folder, Normalizer.Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+            // normalise user folder : remove accents and non ascii characters
+            folder = CoreUtil.getCleanString(folder);
 
             GRIDAClient client = CoreUtil.getGRIDAClient();
             while (client.exist(Server.getInstance().getDataManagerUsersHome() + "/" + folder)) {

--- a/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/CoreUtil.java
+++ b/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/CoreUtil.java
@@ -41,6 +41,9 @@ import fr.insalyon.creatis.vip.core.client.view.CoreConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.text.Normalizer;
+
 /**
  *
  * @author Rafael Ferreira da Silva
@@ -92,5 +95,36 @@ public class CoreUtil {
             server.getGRIDAHost(),
             server.getGRIDAPort(),
             server.getServerProxy(server.getVoName()));
+    }
+
+
+    /*
+        remove accents and non-ascii characters
+    */
+    public static String getCleanString(String s) {
+        return getCleanString(s, true, true);
+    }
+
+    public static String getCleanString(
+            String s, boolean removeAccents, boolean onlyKeepAscii) {
+        if ( removeAccents) {
+            // Normalizer.normalize with NFKD form decompose accentuated
+            // letters into separate "accent mark + base letter" characters
+            s = Normalizer.normalize(s, Normalizer.Form.NFKD);
+        }
+
+        if (onlyKeepAscii) {
+            // the [^\\p{ASCII}] regex remove all non-ascii characters
+            // so also the separated accents char if removeAccents is true
+            return s.replaceAll("[^\\p{ASCII}]", "");
+        } else if (removeAccents) {
+            // the '\p{M}' regex remove all the combining marks (accents and
+            // other exotic stuff) and is less strict than onlyKeepAscii
+            // for instance it will keep 'œ' '«' '»' '°'
+            return s.replaceAll("\\p{M}", "");
+        } else {
+            // nothing to do
+            return s;
+        }
     }
 }

--- a/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/DataManagerUtil.java
+++ b/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/DataManagerUtil.java
@@ -32,6 +32,7 @@
 package fr.insalyon.creatis.vip.datamanager.server;
 
 import fr.insalyon.creatis.vip.core.client.bean.*;
+import fr.insalyon.creatis.vip.core.server.business.CoreUtil;
 import fr.insalyon.creatis.vip.core.server.business.Server;
 import fr.insalyon.creatis.vip.core.server.dao.*;
 import fr.insalyon.creatis.vip.datamanager.client.DataManagerConstants;
@@ -41,6 +42,7 @@ import java.io.File;
 import java.net.URI;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.text.Normalizer;
 import java.util.*;
 
 /**
@@ -243,5 +245,13 @@ public class DataManagerUtil {
             dir.mkdirs();
         }
         return rootDirectory;
+    }
+
+    /*
+        remove spaces, accents and non-ascii characters
+     */
+    public static String getCleanFilename(String fileName) {
+        fileName = new File(fileName).getName().trim().replaceAll(" ", "_");
+        return CoreUtil.getCleanString(fileName);
     }
 }

--- a/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/GirderStorageBusiness.java
+++ b/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/GirderStorageBusiness.java
@@ -39,6 +39,7 @@ import fr.insalyon.creatis.vip.core.client.view.*;
 import fr.insalyon.creatis.vip.core.server.business.*;
 import fr.insalyon.creatis.vip.datamanager.client.bean.ExternalPlatform;
 import fr.insalyon.creatis.vip.datamanager.client.bean.ExternalPlatform.Type;
+import fr.insalyon.creatis.vip.datamanager.server.DataManagerUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -186,8 +187,8 @@ public class GirderStorageBusiness {
                 new ObjectMapper().readValue(res.response, ObjectNode.class);
             String name = node.get("name").asText();
 
-            //remove spaces from filename
-            return name.replace(' ', '_');
+            // clean filename as in an uploaded file
+            return DataManagerUtil.getCleanFilename(name);
         } catch (IOException ex) {
             logger.error("Error getting girder filename for {} with token {}",
                     fileId, token, ex);

--- a/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/rpc/FileUploadServiceImpl.java
+++ b/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/rpc/FileUploadServiceImpl.java
@@ -120,8 +120,7 @@ public class FileUploadServiceImpl extends HttpServlet {
 
                     boolean local = this.path.equals("local") ? true : false;
                     String rootDirectory = DataManagerUtil.getUploadRootDirectory(local);
-                    fileName = new File(fileName).getName().trim().replaceAll(" ", "_");
-                    fileName = Normalizer.normalize(fileName, Normalizer.Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+                    fileName = DataManagerUtil.getCleanFilename(fileName);
                     File uploadedFile = new File(rootDirectory + fileName);
 
                     try (Connection connection = PlatformConnection.getInstance().getConnection()) {


### PR DESCRIPTION
issues #203 and #204 

This changes :
- filename have the same treatments in the api as in the vip portal (spaces replaced by _, accents and non-ascii chars removed)
- execution inputs have the same treatments in the api as in the vip portal (only a short white list of characters) + the `[]` brackets as needed in some gate api executions

Also :
- uri are now decoded in the rest data api (percent encoding. %20 => ' '). this was a bug
- cleaning and accents removing is improved and more strict, as I see reason to remove accents but to keep non-ascii characters. And this should correct some issues with some users that had strange characters in their name resulting in bug on signup when creating their home folder #203 

Exemple of filename to test in the api :
- `max _ - aà aÀ aầ -« _» eé eè eêfin t~ 6œ cç`
- <==>
- `max%20_%20-%20a%C3%A0%20a%C3%80%20a%E1%BA%A7%20-%C2%AB%20_%C2%BB%20e%C3%A9%20e%C3%A8%20e%C3%AAfin%20t%7E%206%C5%93%20c%C3%A7`