### PR TITLE
init messages at the right place

### DIFF
--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/ApiException.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/ApiException.java
@@ -56,15 +56,15 @@ public class ApiException extends VipException {
         ApiError(Integer code) { this.code = code; }
         @Override
         public Integer getCode() { return code; }
-    }
 
-    static {
-        addMessage(ApiError.GENERIC_API_ERROR, "An error has been encountered on the VIP API", 0);
-        addMessage(ApiError.NOT_IMPLEMENTED, "The {} method is not implemented in the VIP API", 1);
-        addMessage(ApiError.INVALID_PIPELINE_IDENTIFIER, "The {} pipeline identifier is not valid", 1);
-        addMessage(ApiError.APPLICATION_NOT_FOUND, "The {} application does not exists", 1);
-        addMessage(ApiError.PIPELINE_NOT_FOUND, "The {} pipeline does not exists or cannot be used", 1);
-        addMessage(ApiError.NOT_ALLOWED_TO_USE_APPLICATION, "Not allowed to access application {}", 1);
+        static {
+            addMessage(ApiError.GENERIC_API_ERROR, "An error has been encountered on the VIP API", 0);
+            addMessage(ApiError.NOT_IMPLEMENTED, "The {} method is not implemented in the VIP API", 1);
+            addMessage(ApiError.INVALID_PIPELINE_IDENTIFIER, "The {} pipeline identifier is not valid", 1);
+            addMessage(ApiError.APPLICATION_NOT_FOUND, "The {} application does not exists", 1);
+            addMessage(ApiError.PIPELINE_NOT_FOUND, "The {} pipeline does not exists or cannot be used", 1);
+            addMessage(ApiError.NOT_ALLOWED_TO_USE_APPLICATION, "Not allowed to access application {}", 1);
+        }
     }
 
     public ApiException(String message) {

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/ApplicationException.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/ApplicationException.java
@@ -53,12 +53,12 @@ public class ApplicationException extends VipException implements IsSerializable
         ApplicationError(Integer code) { this.code = code; }
         @Override
         public Integer getCode() { return code; }
-    }
 
-    static {
-        addMessage(ApplicationError.PLATFORM_MAX_EXECS, "Max number of running executions reached on the platform.", 0);
-        addMessage(ApplicationError.USER_MAX_EXECS, "Max number of running executions reached.<br />You already have {} running executions.", 1);
-        addMessage(ApplicationError.WRONG_APPLICATION_DESCRIPTOR, "Error getting application descriptor for {}.", 1);
+        static {
+            addMessage(ApplicationError.PLATFORM_MAX_EXECS, "Max number of running executions reached on the platform.", 0);
+            addMessage(ApplicationError.USER_MAX_EXECS, "Max number of running executions reached.<br />You already have {} running executions.", 1);
+            addMessage(ApplicationError.WRONG_APPLICATION_DESCRIPTOR, "Error getting application descriptor for {}.", 1);
+        }
     }
 
     public ApplicationException() {


### PR DESCRIPTION
Before, a BusinessException raised in vip-application before the ApplicationExeption is initialized (that could happen) lead to the error message not configured. That's why the static initializer must be in the error enum and not in the exception class.