### PR TITLE
268 boutiques corrections

### DIFF
--- a/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/JSONUtil.java
+++ b/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/JSONUtil.java
@@ -48,8 +48,8 @@ public class JSONUtil {
         bt.setToolVersion(getPropertyAsString(jsonObject, "tool-version"));
         bt.setDescription(getPropertyAsString(jsonObject, "description"));
         bt.setCommandLine(getPropertyAsString(jsonObject, "command-line"));
-        bt.setDockerImage(getPropertyAsString(jsonObject, "docker-image"));
-        bt.setDockerIndex(getPropertyAsString(jsonObject, "docker-index"));
+        bt.setContainerImage(getPropertyAsString(jsonObject, "docker-image"));
+        bt.setContainerIndex(getPropertyAsString(jsonObject, "docker-index"));
         bt.setSchemaVersion(getPropertyAsString(jsonObject, "schema-version"));
         bt.setChallengerEmail(getPropertyAsString(jsonObject, "vip:miccai-challenger-email"));
         bt.setChallengerTeam(getPropertyAsString(jsonObject, "vip:miccai-challenge-team-name"));
@@ -74,6 +74,13 @@ public class JSONUtil {
                 String value = getPropertyAsString(tagsJSONObject, key);
                 bt.addTag(key, value);
             }
+        }
+
+        JSONObject containerObject = getPropertyAsObject(jsonObject, "container-image");
+        if (containerObject != null) {
+            bt.setContainerType(getPropertyAsString(containerObject, "type"));
+            bt.setContainerImage(getPropertyAsString(containerObject, "image"));
+            bt.setContainerIndex(getPropertyAsString(containerObject, "index"));
         }
 
         bt.setJsonFile(jsonObject.toString());

--- a/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/bean/BoutiquesTool.java
+++ b/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/bean/BoutiquesTool.java
@@ -49,8 +49,9 @@ public class BoutiquesTool implements IsSerializable {
     private String toolVersion;
     private String description;
     private String commandLine;
-    private String dockerImage;
-    private String dockerIndex;
+    private String containerType;
+    private String containerImage;
+    private String containerIndex;
     private String schemaVersion;
     private String challengerEmail;
     private String challengerTeam;
@@ -85,12 +86,16 @@ public class BoutiquesTool implements IsSerializable {
         return commandLine;
     }
 
-    public String getDockerImage() {
-        return dockerImage;
+    public String getContainerType() {
+        return containerType;
     }
 
-    public String getDockerIndex() {
-        return dockerIndex;
+    public String getContainerImage() {
+        return containerImage;
+    }
+
+    public String getContainerIndex() {
+        return containerIndex;
     }
 
     public String getSchemaVersion() {
@@ -120,7 +125,7 @@ public class BoutiquesTool implements IsSerializable {
     public void setJsonFile(String jsonFile) {
         this.jsonFile = jsonFile;
     }
-    
+
     public void setApplicationLFN(String applicationLFN) {
         this.applicationLFN = applicationLFN;
     }
@@ -140,10 +145,10 @@ public class BoutiquesTool implements IsSerializable {
     public String getGwendiaLFN() {
         return this.applicationLFN + "/workflow/" + getName() + ".gwendia";
     }
- 
     public String getJsonLFN() {
         return this.applicationLFN + "/json/" + getName() + ".json";
     }
+
     public void setName(String name) {
         this.name = name;
     }
@@ -164,12 +169,16 @@ public class BoutiquesTool implements IsSerializable {
         this.commandLine = commandLine;
     }
 
-    public void setDockerImage(String dockerImage) {
-        this.dockerImage = dockerImage;
+    public void setContainerType(String containerType) {
+        this.containerType = containerType;
     }
 
-    public void setDockerIndex(String dockerIndex) {
-        this.dockerIndex = dockerIndex;
+    public void setContainerImage(String containerImage) {
+        this.containerImage = containerImage;
+    }
+
+    public void setContainerIndex(String containerIndex) {
+        this.containerIndex = containerIndex;
     }
 
     public void setSchemaVersion(String schemaVersion) {
@@ -199,5 +208,4 @@ public class BoutiquesTool implements IsSerializable {
     public boolean hasNextInput(BoutiquesInput input) {
         return inputs.lastIndexOf(input) < (inputs.size()-1) ? true : false;
     }
-
 }

--- a/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/DisplayTab.java
+++ b/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/DisplayTab.java
@@ -203,6 +203,11 @@ public class DisplayTab extends Tab {
         if (boutiquesTool.getAuthor() == null) {
             throw new ApplicationImporterException("Boutiques file must have an author");
         }
+
+        String containerType = boutiquesTool.getContainerType();
+        if (containerType != null && ! containerType.equals("docker")) {
+            throw new ApplicationImporterException("Only docker containers are supported");
+        }
     }
 
     /**

--- a/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/DisplayTab.java
+++ b/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/DisplayTab.java
@@ -197,6 +197,9 @@ public class DisplayTab extends Tab {
         if (boutiquesTool.getName() == null) {
             throw new ApplicationImporterException("Boutiques file must have a name property");
         }
+        if (boutiquesTool.getName().matches("\\s")) {
+            throw new ApplicationImporterException("Application name should not have a space in it");
+        }
         if (boutiquesTool.getToolVersion() == null) {
             throw new ApplicationImporterException("Boutiques file must have a tool-version property");
         }

--- a/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/DisplayTab.java
+++ b/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/DisplayTab.java
@@ -206,11 +206,6 @@ public class DisplayTab extends Tab {
         if (boutiquesTool.getAuthor() == null) {
             throw new ApplicationImporterException("Boutiques file must have an author");
         }
-
-        String containerType = boutiquesTool.getContainerType();
-        if (containerType != null && ! containerType.equals("docker")) {
-            throw new ApplicationImporterException("Only docker containers are supported");
-        }
     }
 
     /**

--- a/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/DisplayTab.java
+++ b/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/DisplayTab.java
@@ -197,7 +197,7 @@ public class DisplayTab extends Tab {
         if (boutiquesTool.getName() == null) {
             throw new ApplicationImporterException("Boutiques file must have a name property");
         }
-        if (boutiquesTool.getName().matches("\\s")) {
+        if (boutiquesTool.getName().matches(".*\\s.*")) {
             throw new ApplicationImporterException("Application name should not have a space in it");
         }
         if (boutiquesTool.getToolVersion() == null) {

--- a/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/GeneralLayout.java
+++ b/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/GeneralLayout.java
@@ -69,8 +69,8 @@ public class GeneralLayout extends AbstractFormLayout {
         version.setValue(bt.getToolVersion());
         description.setValue(bt.getDescription());
         commandLine.setValue(bt.getCommandLine());
-        dockerImage.setValue(bt.getDockerImage());
-        dockerIndex.setValue(bt.getDockerIndex());
+        dockerImage.setValue(bt.getContainerImage());
+        dockerIndex.setValue(bt.getContainerIndex());
         schemaVersion.setValue(bt.getSchemaVersion());
     }
 

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/launch/InputLayout.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/launch/InputLayout.java
@@ -325,7 +325,7 @@ public class InputLayout extends AbstractSourceLayout {
     
     @Override
     public boolean isValueModifiable() {
-        if (getValue().equalsIgnoreCase(ApplicationConstants.INPUT_WITHOUT_VALUE) || getValue().equalsIgnoreCase(DataManagerConstants.ROOT + "/" + DataManagerConstants.USERS_HOME)) {
+        if ( (optional && ! isOptionalChecked()) || getValue().equalsIgnoreCase(DataManagerConstants.ROOT + "/" + DataManagerConstants.USERS_HOME)) {
             return true;
         } 
         return false;

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/launch/LaunchFormLayout.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/launch/LaunchFormLayout.java
@@ -230,10 +230,13 @@ public class LaunchFormLayout extends AbstractFormLayout {
 
         asls.stream().forEach(
             asl -> {
+                String newValue = valuesMap.get(asl.getName());
                 if (asl.isOptional()) {
+                    if (ApplicationConstants.INPUT_WITHOUT_VALUE.equalsIgnoreCase(newValue)) {
+                        return;
+                    }
                     asl.enableInput();
                 }
-                String newValue = valuesMap.get(asl.getName());
                 asl.setValue(newValue);
             });
     }

--- a/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/VipSessionBusiness.java
+++ b/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/VipSessionBusiness.java
@@ -10,12 +10,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -111,10 +113,11 @@ public class VipSessionBusiness {
     }
 
     private Map<String, String> getCookies(HttpServletRequest request) {
-        return Stream.of(request.getCookies())
-                .collect(Collectors.toMap(
-                        cookie -> cookie.getName(),
-                        cookie -> decodeCookieValue(cookie.getValue())));
+        HashMap<String,String> cookiesMap = new HashMap<>();
+        for (Cookie cookie : request.getCookies()) {
+            cookiesMap.put(cookie.getName(), decodeCookieValue(cookie.getValue()));
+        }
+        return cookiesMap;
     }
 
     private String decodeCookieValue(String encodedValue) {

--- a/vip-portal/src/main/resources/vm/wrapper.vm
+++ b/vip-portal/src/main/resources/vm/wrapper.vm
@@ -75,10 +75,14 @@ case $key in
         then
             if [ "$count" -gt "0" ]
             then 
-                echo ",\"$input.getId()\" : \"$2\"" >> input_param_file.json
-            else
-                echo "\"$input.getId()\" : \"$2\"" >> input_param_file.json
+                echo ",\" >> input_param_file.json
             fi
+            echo "\"$input.getId()\" : " >> input_param_file.json
+            #if($input.getType()=="Flag" || $input.getType()=="Number")
+            echo $2 >> input_param_file.json
+            #else
+            echo "\"$2\""  >> input_param_file.json
+            #end
         count=$((count+1))
         fi
     ;;

--- a/vip-portal/src/main/resources/vm/wrapper.vm
+++ b/vip-portal/src/main/resources/vm/wrapper.vm
@@ -64,7 +64,7 @@ cat << JSONPARAMETERS  > input_param_file.json
 {
 JSONPARAMETERS
 
-count=0
+firstParam=true
 while [[ $# > 0 ]]
 do
 key="$1"
@@ -73,17 +73,27 @@ case $key in
 --$input.getId().toLowerCase())
         if [ "$2" != "No_value_provided" ]
         then
-            if [ "$count" -gt "0" ]
-            then 
-                echo ",\" >> input_param_file.json
-            fi
-            echo "\"$input.getId()\" : " >> input_param_file.json
-            #if($input.getType()=="Flag" || $input.getType()=="Number")
-            echo $2 >> input_param_file.json
+            #if($input.getType()=="Flag")
+            if [ "$firstParam" != true ] && [ "$2" = true ]
             #else
-            echo "\"$2\""  >> input_param_file.json
+            if [ "$firstParam" != true ]
             #end
-        count=$((count+1))
+            then 
+                echo "," >> input_param_file.json
+            fi
+            #if($input.getType()=="Flag") ## for the current boutiques version, a flag must be true or absent (false not allowed)
+            if [ "$2" = true ]
+            then
+                echo "\"$input.getId()\": $2"  >> input_param_file.json
+                firstParam=false
+            fi
+            #elseif($input.getType()=="Number")
+            echo "\"$input.getId()\": $2"  >> input_param_file.json
+            firstParam=false
+            #else ## text or file, put in quotes
+            echo "\"$input.getId()\": \"$2\""  >> input_param_file.json
+            firstParam=false
+            #end
         fi
     ;;
     #end


### PR DESCRIPTION
Based on the #267 PR that should be accepted first for a better readibility.

Several correction for #268. Some implementation notes :
- boutiques file allows several container technology, only docker is supported on VIP import
- space in a application name causes an importation error
- boutiques type "Number" are generated as json number in the json parameter file
- boutiques type "Flag" are generated as json boolean in the json parameter file, **but only** if it is true. It is absent if it is false, as this is imposed in the boutiques version currently in use. As Flag are optional, they can be absent by default, they can be present by default (with a `default-value:true` in the boutiques file), and this default behavior can be overridden by true/false value in the execution launch form. Note that a `default-value:false` in the boutiques file is valid but has no use and can cause a bug in a vip execution.
- `No_value_provided` in relaunch is not easy to take into account as there are many many cases possible and it seems not useful to make a big effort to cover everything. I choose a simple solution that covers the most important use cases : `No_value_provided` are ignored in relaunched execution or in examples (and do not override or activate the input) ; and any real value (other than `No_value_provided`) overrides and activates a deactivated input (without conflict).

Also includes a session recovery correction because there was a bug when a cookie was duplicated.