### PR TITLE
not an error if no somme row in gatelab db

### DIFF
--- a/vip-gatelab/src/main/java/fr/insalyon/creatis/vip/gatelab/server/dao/derby/GateLabData.java
+++ b/vip-gatelab/src/main/java/fr/insalyon/creatis/vip/gatelab/server/dao/derby/GateLabData.java
@@ -70,7 +70,13 @@ public class GateLabData extends AbstractJobData implements GateLabDAO {
         try {
             PreparedStatement ps = connection.prepareStatement("SELECT somme FROM somme ");
             ResultSet rs = ps.executeQuery();
-            rs.next();
+            boolean hasNext = rs.next();
+
+            if ( ! hasNext) {
+                // no row in somme table, no job is running yet
+                ps.close();
+                return 0;
+            }
             
             long sum = rs.getLong("somme");
             
@@ -79,7 +85,7 @@ public class GateLabData extends AbstractJobData implements GateLabDAO {
 
         } catch (SQLException ex) {
             logger.error("Error fetching simulation particle number", ex);
-            return 0;
+            throw new DAOException(ex);
         } finally {
             close(logger);
         }


### PR DESCRIPTION
If there is no data in the `Somme` table, it is not considered an error anymore.

@camarasu But I am not sure what to do when there is an error (h2 server issue, no table because of workflow issue) : do we still silence it for the user and return 0 (as before), or do we throw an error (as proposed).