### PR TITLE
Improve data management

### DIFF
--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/DataApiBusiness.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/DataApiBusiness.java
@@ -33,6 +33,7 @@ package fr.insalyon.creatis.vip.api.business;
 
 import fr.insalyon.creatis.vip.api.CarminProperties;
 import fr.insalyon.creatis.vip.api.exception.ApiException;
+import fr.insalyon.creatis.vip.api.exception.ApiException.ApiError;
 import fr.insalyon.creatis.vip.api.model.PathProperties;
 import fr.insalyon.creatis.vip.api.model.UploadData;
 import fr.insalyon.creatis.vip.api.model.UploadDataType;
@@ -281,12 +282,13 @@ public class DataApiBusiness {
     private void checkPermission(String path, LFCAccessType accessType)
             throws ApiException {
         try {
-            lfcPermissionBusiness.checkPermission(
-                currentUserProvider.get(), path, accessType);
+            if ( ! lfcPermissionBusiness.isLFCPathAllowed(
+                currentUserProvider.get(), path, accessType, true)) {
+                throw new ApiException(ApiError.UNAUTHORIZED_DATA_ACCESS, path);
+            }
         } catch (BusinessException e) {
-            throw new ApiException("API Permission error", e);
+            throw new ApiException("Error when checking permissions", e);
         }
-        // all check passed : all good !
     }
 
     // #### DOWNLOAD STUFF

--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/exception/ApiException.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/exception/ApiException.java
@@ -55,7 +55,8 @@ public class ApiException extends VipException {
         INPUT_FIELD_NOT_VALID(8009),
         WRONG_DATE_FORMAT(8010),
         WRONG_STAT_SERVICE(8011),
-        COUNTRY_UNKNOWN(8012);
+        COUNTRY_UNKNOWN(8012),
+        UNAUTHORIZED_DATA_ACCESS(8013);
 
         private Integer code;
         ApiError(Integer code) { this.code = code; }
@@ -75,6 +76,7 @@ public class ApiException extends VipException {
             addMessage(ApiError.WRONG_DATE_FORMAT, "The date {} have a wrong format (needed : {})", 2);
             addMessage(ApiError.WRONG_STAT_SERVICE, "The service {} is unknown, only 'vip' is possible", 1);
             addMessage(ApiError.COUNTRY_UNKNOWN, "Country unknown : {}", 1);
+            addMessage(ApiError.UNAUTHORIZED_DATA_ACCESS, "Unauthorized data access to : {}", 1);
         }
 
         public Optional<String> getMessage() {

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/BoutiquesBusiness.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/BoutiquesBusiness.java
@@ -74,10 +74,7 @@ public class BoutiquesBusiness {
 
         // fetch json file
         String jsonLfn = getJsonLfn(applicationName, version);
-        String localDirectory = server.getApplicationImporterFileRepository()
-                + "/publications/" + applicationName + "/" + version;
-        String localFile = dataManagerBusiness.getRemoteFile(
-            user, jsonLfn, localDirectory);
+        String localFile = dataManagerBusiness.getRemoteFile(user, jsonLfn);
 
         // TODO : verify it has an author (refactor boutique parser from application-importer
 

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowBusiness.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowBusiness.java
@@ -271,11 +271,8 @@ public class WorkflowBusiness {
 
             AppVersion version = applicationDAO.getVersion(
                     applicationName, applicationVersion);
-            String workflowPath = dataManagerBusiness.getRemoteFile(
-                user,
-                version.getLfn(),
-                server.getConfigurationFolder() + "workflows/"
-                        + FilenameUtils.getName(version.getLfn()));
+            String workflowPath =
+                    dataManagerBusiness.getRemoteFile(user, version.getLfn());
 
             //selectRandomEngine could also be used; TODO: make this choice configurable
             Engine engine = selectEngine(applicationClass);
@@ -429,12 +426,8 @@ public class WorkflowBusiness {
 
         try {
             AppVersion version = applicationDAO.getVersion(applicationName, applicationVersion);
-            String localDirectory = server.getConfigurationFolder()
-                    + "workflows/"
-                    + FilenameUtils.getPath(version.getLfn()) + "/"
-                    + FilenameUtils.getName(version.getLfn());
-            String workflowPath = dataManagerBusiness.getRemoteFile(
-                user, version.getLfn(), localDirectory);
+            String workflowPath =
+                    dataManagerBusiness.getRemoteFile(user, version.getLfn());
             return workflowPath.endsWith(".gwendia")
                     ? getGwendiaParser().parse(workflowPath)
                     : getScuflParser().parse(workflowPath);

--- a/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/client/DataManagerConstants.java
+++ b/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/client/DataManagerConstants.java
@@ -96,5 +96,6 @@ public class DataManagerConstants {
     public static final String VO_ROOT_FOLDER = "VO root folder";
     public static final String GROUP_APPEND = " (group)";
     public static final int MAX_OPERATIONS_LIMIT = 10;
+    public static final String DOWNLOAD_FOLDER = "downloads";
 
 }

--- a/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/DataManagerBusiness.java
+++ b/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/DataManagerBusiness.java
@@ -132,15 +132,21 @@ public class DataManagerBusiness {
         }
     }
 
-    public String getRemoteFile(User user, String remoteFile, String localDir)
+    public String getRemoteFile(User user, String remoteFile)
             throws BusinessException {
 
+        String remotePath;
+        String localDir;
         try {
-            return gridaClient.getRemoteFile(
-                    lfcPathsBusiness.parseBaseDir(user, remoteFile),
-                    localDir);
+            remotePath = lfcPathsBusiness.parseBaseDir(user, remoteFile);
+            localDir = lfcPathsBusiness.getLocalDirForGridaFileDownload(remotePath);
         } catch (DataManagerException ex) {
             throw new BusinessException(ex);
+        }
+        try {
+            return gridaClient.getRemoteFile(
+                    remotePath,
+                    localDir);
         } catch (GRIDAClientException ex) {
             logger.error("Error getting file {} to {} by {}",
                     remoteFile, localDir, user, ex);

--- a/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/LFCPermissionBusiness.java
+++ b/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/LFCPermissionBusiness.java
@@ -36,13 +36,13 @@ import fr.insalyon.creatis.vip.core.client.view.user.UserLevel;
 import fr.insalyon.creatis.vip.core.server.business.BusinessException;
 import fr.insalyon.creatis.vip.datamanager.client.bean.*;
 import fr.insalyon.creatis.vip.datamanager.client.view.DataManagerException;
-import fr.insalyon.creatis.vip.datamanager.server.DataManagerUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.file.Paths;
 import java.util.*;
 
 import static fr.insalyon.creatis.vip.datamanager.client.DataManagerConstants.*;
@@ -69,33 +69,36 @@ public class LFCPermissionBusiness {
         READ, UPLOAD, DELETE
     }
 
-    public void checkPermission(User user, String path, LFCAccessType LFCAccessType)
+    public Boolean isLFCPathAllowed(User user, String path, LFCAccessType LFCAccessType, Boolean disableAdminAccess)
             throws BusinessException {
-        // TODO : verify there is no problem with ".." (normalize if its the case)
-        checkRootPermission(path, LFCAccessType);
-        // Root is always filtered so always permited
-        if (path.equals(ROOT)) return;
+        // normalize to remove "..".
+        path = Paths.get(path).normalize().toString();
+        if ( ! isRootOK(user, path, LFCAccessType)) return false;
+
+        // Root is always filtered so always permitted
+        if (path.equals(ROOT)) return true;
+        // do not delete synchronized stuff
+        if (LFCAccessType == LFCPermissionBusiness.LFCAccessType.DELETE
+            && isSynchronized(user, path)) {
+            return false;
+        }
         // else it all depends of the first directory
         String firstDir = getFirstDirectoryName(path);
         // always can access its home and its trash
-        if (firstDir.equals(USERS_HOME)) return;
-        if (firstDir.equals(TRASH_HOME)) return;
-        // currently no admin access is possible via the api for security reasons
+        if (firstDir.equals(USERS_HOME)) return true;
+        if (firstDir.equals(TRASH_HOME)) return true;
         if (firstDir.equals(USERS_FOLDER) || firstDir.equals(VO_ROOT_FOLDER)) {
-            logger.error("Trying to access admin folders from api : {}", path);
-            throw new BusinessException("Unauthorized LFC access");
+            // restricted to admin
+            return isAdminAllowed(user, path, disableAdminAccess);
         }
         // else it should be a group folder
         if (!firstDir.endsWith(GROUP_APPEND)) {
-            logger.error("Unexpected lfc access to: " + firstDir);
-            throw new BusinessException("Unauthorized LFC access");
+            logger.error("({}) Wrong lfc access to '{}'",
+                    user.getEmail(), path);
+            return false;
         }
         String groupName = firstDir.substring(0,firstDir.length()-GROUP_APPEND.length());
-        checkGroupPermission(user, groupName, LFCAccessType);
-        if (LFCAccessType == LFCPermissionBusiness.LFCAccessType.DELETE) {
-            checkSynchronizedDirectories(user, path);
-        }
-        // all check passed : all good !
+        return isGroupAllowed(user, groupName, LFCAccessType);
     }
 
     private String getFirstDirectoryName(String path) {
@@ -108,40 +111,62 @@ public class LFCPermissionBusiness {
         }
     }
 
-    private void checkRootPermission(
-            String path, LFCAccessType LFCAccessType)
+    private Boolean isRootOK(
+            User user, String path, LFCAccessType LFCAccessType)
             throws BusinessException {
         // verify path begins with the root
         if (!path.startsWith(ROOT)) {
-            logger.error("Access to a lfc not starting with the root:" + path);
-            throw new BusinessException("Unauthorized LFC access");
+            logger.error("({}) Access to a lfc not starting with the root '{}'",
+                    user.getEmail(), path);
+            return false;
         }
         // read always possible
-        if (LFCAccessType == LFCPermissionBusiness.LFCAccessType.READ) return;
+        if (LFCAccessType == LFCPermissionBusiness.LFCAccessType.READ) {
+            return true;
+        }
         // else it cannot be THE root nor a direct subdirectory of root
         if (path.equals(ROOT) ||
                 path.lastIndexOf('/') == ROOT.length()) {
-            logger.error("Unexpected lfc access to: " + path);
-            throw new BusinessException("Unauthorized LFC access");
+            logger.error("({}) Unexpected write lfc access to '{}'",
+                    user.getEmail(), path);
+            return false;
         }
+        return true;
     }
 
-    private void checkGroupPermission(
-            User user, String groupname, LFCAccessType LFCAccessType)
+    private boolean isAdminAllowed(User user, String path, Boolean disableAdminAccess) {
+        if ( ! user.isSystemAdministrator()) {
+            logger.error("({}) Non admin trying to access an admin folder : {}",
+                    user.getEmail(), path);
+            return false;
+        }
+        if (disableAdminAccess) {
+            logger.error("({}) LFC access disabled to admin : {}",
+                    user.getEmail(), path);
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isGroupAllowed(
+            User user, String groupName, LFCAccessType LFCAccessType)
             throws BusinessException {
+        // user must have access to this group
+        if (!user.hasGroupAccess(groupName)) {
+            logger.error("({}) Trying to access an unauthorized goup '{}'",
+                    user.getEmail(), groupName);
+            return false;
+        }
         // beginner cant write/delete in groups folder
         if (LFCAccessType != LFCPermissionBusiness.LFCAccessType.READ && user.getLevel() == UserLevel.Beginner) {
-            logger.error("beginner user try to upload/delete in a group:" + user.getEmail() +"/" + groupname);
-            throw new BusinessException("Unauthorized LFC access");
+            logger.error("({}) Beginner user try to upload/delete in a group '{}'",
+                    user.getEmail(), groupName);
+            return false;
         }
-        // otherwise it must have access to this group
-        if (!user.hasGroupAccess(groupname)) {
-            logger.error("Trying to access an unauthorized goup");
-            throw new BusinessException("Unauthorized LFC access");
-        }
+        return true;
     }
 
-    private void checkSynchronizedDirectories(User user, String path)
+    private boolean isSynchronized(User user, String path)
             throws BusinessException {
         List<SSH> sshs = dataManagerBusiness.getSSHConnections();
         List<String> lfcDirSSHSynchronization = new ArrayList<>();
@@ -159,10 +184,11 @@ public class LFCPermissionBusiness {
         }
         for (String s : lfcDirSSHSynchronization) {
             if (lfcBaseDir.startsWith(s)) {
-                logger.error("Try to delete  synchronized file :" + path);
-                throw new BusinessException("Illegal data API access");
+                logger.error("({}) Try to delete  synchronized file '{}'", user.getEmail(), path);
+                return false;
             }
         }
+        return true;
     }
 
 }

--- a/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/TransferPoolBusiness.java
+++ b/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/TransferPoolBusiness.java
@@ -231,8 +231,7 @@ public class TransferPoolBusiness {
             lfcBusiness.getModificationDate(user, remoteFile);
 
             String remotePath = lfcPathsBusiness.parseBaseDir(user, remoteFile);
-            String localDirPath = serverConfiguration.getDataManagerPath()
-                    + "/downloads" + FilenameUtils.getFullPath(remotePath);
+            String localDirPath = lfcPathsBusiness.getLocalDirForGridaFileDownload(remotePath);
 
             return gridaPoolClient.downloadFile(remotePath, localDirPath, user.getEmail());
 
@@ -256,8 +255,8 @@ public class TransferPoolBusiness {
                 remotePaths.add(
                         lfcPathsBusiness.parseBaseDir(user, remoteFile));
             }
-            String localDirPath = serverConfiguration.getDataManagerPath()
-                    + "/downloads/" + packName;
+            String localDirPath =
+                    lfcPathsBusiness.getLocalDirForGridaMultiFilesDownload(packName);
 
             return gridaPoolClient.downloadFiles(remotePaths.toArray(new String[]{}),
                     localDirPath, user.getEmail());
@@ -276,10 +275,8 @@ public class TransferPoolBusiness {
         try {
             lfcBusiness.getModificationDate(user, remoteFolder);
 
-            String remotePath = lfcPathsBusiness.parseBaseDir(
-                user, remoteFolder);
-            String localDirPath = serverConfiguration.getDataManagerPath()
-                    + "/downloads" + remotePath;
+            String remotePath = lfcPathsBusiness.parseBaseDir(user, remoteFolder);
+            String localDirPath = lfcPathsBusiness.getLocalDirForGridaFolderDownload(remotePath);
             return gridaPoolClient.downloadFolder(
                     remotePath, localDirPath, user.getEmail());
 

--- a/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/rpc/FileDownloadServiceImpl.java
+++ b/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/rpc/FileDownloadServiceImpl.java
@@ -139,7 +139,7 @@ public class FileDownloadServiceImpl extends HttpServlet {
         }
 
         Path path = Paths.get(vipPath);
-        if (path.isAbsolute()) {
+        if ( ! path.isAbsolute()) {
             logger.error("download path [{}] should be absolute for user {}", path, user.getEmail());
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Path should be absolute");
             return;

--- a/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/rpc/FileDownloadServiceImpl.java
+++ b/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/rpc/FileDownloadServiceImpl.java
@@ -76,6 +76,7 @@ public class FileDownloadServiceImpl extends HttpServlet {
         super.init();
         ApplicationContext applicationContext =
                 WebApplicationContextUtils.findWebApplicationContext(getServletContext());
+        lfcPathsBusiness = applicationContext.getBean(LfcPathsBusiness.class);
         gridaPoolClient = applicationContext.getBean(GRIDAPoolClient.class);
         lfcPermissionBusiness = applicationContext.getBean(LFCPermissionBusiness.class);
     }

--- a/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/rpc/FileDownloadServiceImpl.java
+++ b/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/rpc/FileDownloadServiceImpl.java
@@ -31,16 +31,15 @@
  */
 package fr.insalyon.creatis.vip.datamanager.server.rpc;
 
+import fr.insalyon.creatis.grida.client.GRIDAClientException;
 import fr.insalyon.creatis.grida.client.GRIDAPoolClient;
 import fr.insalyon.creatis.grida.common.bean.Operation;
 import fr.insalyon.creatis.vip.core.client.bean.User;
 import fr.insalyon.creatis.vip.core.client.view.CoreConstants;
-import fr.insalyon.creatis.vip.core.server.business.CoreUtil;
-import fr.insalyon.creatis.vip.core.server.business.Server;
-import fr.insalyon.creatis.vip.datamanager.server.business.DataManagerBusiness;
-import fr.insalyon.creatis.vip.datamanager.server.business.LFCBusiness;
-import fr.insalyon.creatis.vip.datamanager.server.business.LfcPathsBusiness;
-import fr.insalyon.creatis.vip.datamanager.server.business.TransferPoolBusiness;
+import fr.insalyon.creatis.vip.core.server.business.BusinessException;
+import fr.insalyon.creatis.vip.datamanager.client.view.DataManagerException;
+import fr.insalyon.creatis.vip.datamanager.server.business.*;
+import fr.insalyon.creatis.vip.datamanager.server.business.LFCPermissionBusiness.LFCAccessType;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,8 +55,11 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
-/**
+    /**
  *
  * @author Rafael Silva
  */
@@ -66,6 +68,8 @@ public class FileDownloadServiceImpl extends HttpServlet {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private GRIDAPoolClient gridaPoolClient;
+    private LFCPermissionBusiness lfcPermissionBusiness;
+    private LfcPathsBusiness lfcPathsBusiness;
 
     @Override
     public void init() throws ServletException {
@@ -73,6 +77,7 @@ public class FileDownloadServiceImpl extends HttpServlet {
         ApplicationContext applicationContext =
                 WebApplicationContextUtils.findWebApplicationContext(getServletContext());
         gridaPoolClient = applicationContext.getBean(GRIDAPoolClient.class);
+        lfcPermissionBusiness = applicationContext.getBean(LFCPermissionBusiness.class);
     }
 
     @Override
@@ -82,43 +87,105 @@ public class FileDownloadServiceImpl extends HttpServlet {
         try {
             User user = (User) req.getSession().getAttribute(CoreConstants.SESSION_USER);
             String operationId = req.getParameter("operationid");
+            String vipPath = req.getParameter("path");
 
-            if (user != null && operationId != null && !operationId.isEmpty()) {
+            if (user == null) {
+                logger.warn("Download from an unlogged user (operationid : {}, path : {})",
+                        operationId, vipPath);
+                resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, "User not logged in");
+                return;
+            }
 
-                    Operation operation = gridaPoolClient.getOperationById(operationId);
-
-                    File file = new File(operation.getDest());
-                    if (file.isDirectory()) {
-                        file = new File(operation.getDest() + "/"
-                                + FilenameUtils.getName(operation.getSource()));
-                    }
-                    int length = 0;
-                    ServletOutputStream op = resp.getOutputStream();
-                    ServletContext context = getServletConfig().getServletContext();
-                    String mimetype = context.getMimeType(file.getName());
-
-                    logger.info("(" + user.getEmail() + ") Downloading '" + file.getAbsolutePath() + "'.");
-
-                    resp.setContentType((mimetype != null) ? mimetype : "application/octet-stream");
-                    resp.setContentLength((int) file.length());
-                    resp.setHeader("Content-Disposition", "attachment; filename=\""
-                            + file.getName() + "\"");
-
-                    byte[] bbuf = new byte[4096];
-                    DataInputStream in = new DataInputStream(new FileInputStream(file));
-
-                    while ((in != null) && ((length = in.read(bbuf)) != -1)) {
-                        op.write(bbuf, 0, length);
-                    }
-
-                    in.close();
-                    op.flush();
-                    op.close();
-
+            if (operationId != null) {
+                downloadByOperationId(user, operationId, resp);
+            } else if (vipPath != null) {
+                downloadByPath(user, vipPath, resp);
+            } else {
+                logger.warn("Download without operation nor path by {}", user.getEmail());
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "No operation id or path provided");
             }
         } catch (Exception ex) {
             logger.error("Error downloading a file", ex);
-            throw new ServletException(ex);
+            throw new ServletException("Error downloading a file", ex);
         }
+    }
+
+    private void downloadByOperationId(
+            User user, String operationId, HttpServletResponse resp)
+            throws GRIDAClientException, IOException, ServletException {
+        if (operationId.isEmpty()) {
+            logger.warn("Empty operationid for download for user {}", user.getEmail());
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Empty operation id");
+            return;
+        }
+
+        Operation operation = gridaPoolClient.getOperationById(operationId);
+
+        File file = new File(operation.getDest());
+        if (file.isDirectory()) {
+            file = new File(operation.getDest() + "/"
+                    + FilenameUtils.getName(operation.getSource()));
+        }
+        downloadFile(user, file, resp);
+    }
+
+    private void downloadByPath(
+            User user, String vipPath, HttpServletResponse resp)
+            throws IOException, BusinessException, DataManagerException, ServletException {
+        if (vipPath.isEmpty()) {
+            logger.warn("Empty operationid for download for user {}", user.getEmail());
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Empty operation id");
+            return;
+        }
+
+        Path path = Paths.get(vipPath);
+        if (path.isAbsolute()) {
+            logger.error("download path [{}] should be absolute for user {}", path, user.getEmail());
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Path should be absolute");
+            return;
+        }
+
+        if ( ! lfcPermissionBusiness.isLFCPathAllowed(
+                user, vipPath, LFCAccessType.READ, false)) {
+            logger.error("download path [{}] not allowed for user {}", path, user.getEmail());
+            resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Access forbidden to this file");
+            return;
+        }
+
+        String remotePath = lfcPathsBusiness.parseBaseDir(user, vipPath);
+        String localFilePath = lfcPathsBusiness.getLocalDownloadPath(remotePath);
+        File localFile = new File(localFilePath);
+        downloadFile(user, localFile, resp);
+    }
+
+    private void downloadFile(User user, File file, HttpServletResponse resp) throws IOException, ServletException {
+        if ( ! file.exists() || file.isDirectory()) {
+            logger.error("({}) download file [{}] not existing or is a directory",
+                    user.getEmail(), file.getAbsolutePath());
+            throw new ServletException("Internal error downloading a file");
+        }
+
+        int length = 0;
+        ServletOutputStream op = resp.getOutputStream();
+        ServletContext context = getServletConfig().getServletContext();
+        String mimetype = context.getMimeType(file.getName());
+
+        logger.info("({}) Downloading '{}'.",user.getEmail(), file.getAbsolutePath());
+
+        resp.setContentType((mimetype != null) ? mimetype : "application/octet-stream");
+        resp.setContentLength((int) file.length());
+        resp.setHeader("Content-Disposition", "attachment; filename=\""
+                + file.getName() + "\"");
+
+        byte[] bbuf = new byte[4096];
+        DataInputStream in = new DataInputStream(new FileInputStream(file));
+
+        while ((in != null) && ((length = in.read(bbuf)) != -1)) {
+            op.write(bbuf, 0, length);
+        }
+
+        in.close();
+        op.flush();
+        op.close();
     }
 }

--- a/vip-local/src/test/java/fr/insalyon/creatis/vip/integrationtest/VipLocalConfigurationIT.java
+++ b/vip-local/src/test/java/fr/insalyon/creatis/vip/integrationtest/VipLocalConfigurationIT.java
@@ -323,7 +323,7 @@ public class VipLocalConfigurationIT {
         // verify output
         Assertions.assertTrue(lfcBusiness.exists(user, resultLFN));
         Path localTempFolder = Files.createTempDirectory("vip-local-test");
-        dataManagerBusiness.getRemoteFile(user, resultLFN, localTempFolder.toString());
+        dataManagerBusiness.getRemoteFile(user, resultLFN);
 
         File result = localTempFolder.resolve(Paths.get(resultLFN).getFileName()).toFile();
         File expected = new ClassPathResource(classpathExpectedResutFile).getFile();

--- a/vip-portal/src/main/webapp/js/ami-viewer.js
+++ b/vip-portal/src/main/webapp/js/ami-viewer.js
@@ -74,7 +74,7 @@ function amiViewer(url, rawExtension, divId) {
   // main table listing all images.  Hence the 2 imbricated tables in
   // the following expression.
   const urlsToLoad = filename.endsWith('.mhd')
-        ? [ [ url, url.replace(/\.mhd$/g, rawExtension) ] ]
+        ? [ [ url, url.replace(/\.mhd$/, rawExtension).replace(/\.mhd&/, rawExtension + "&") ] ]
         : url;
 
   loader

--- a/vip-portal/src/main/webapp/js/ami-viewer.js
+++ b/vip-portal/src/main/webapp/js/ami-viewer.js
@@ -2,10 +2,10 @@
 // https://codesandbox.io/s/github/FNNDSC/ami/tree/master/lessons/03
 
 function amiViewer(url, rawExtension, divId) {
-  const name = url.substring(url.lastIndexOf('/') + 1);
+  const filename = new URL(url).searchParams.get('filename');
   window.setNoticeMessage(
     'Loading and parsing image ' +
-      name +
+      filename +
       '.  Please wait, this may take a while …');
 
   const colors = {
@@ -54,11 +54,11 @@ function amiViewer(url, rawExtension, divId) {
 
   const loader = new window.AMI.VolumeLoader(container);
 
-  if (name.endsWith('.mhd') && rawExtension.length == 0) {
-    const nameWithoutExtension = name.substring(0, name.lastIndexOf('.'));
+  if (filename.endsWith('.mhd') && rawExtension.length == 0) {
+    const nameWithoutExtension = filename.substring(0, name.lastIndexOf('.'));
     window.setWarningMessage(
       'Could not find raw file associated to mhd file: ' +
-        name +
+        filename +
         '.  Tried to find a file with the name ' +
         nameWithoutExtension +
         ' and extensions .raw, .zraw and .raw.gz.');
@@ -73,8 +73,8 @@ function amiViewer(url, rawExtension, divId) {
   // 2 urls for 2 different images, this table must be included in the
   // main table listing all images.  Hence the 2 imbricated tables in
   // the following expression.
-  const urlsToLoad = url.endsWith('.mhd')
-        ? [ [ url, url.replace(/\.mhd$/, rawExtension) ] ]
+  const urlsToLoad = filename.endsWith('.mhd')
+        ? [ [ url, url.replace(/\.mhd$/g, rawExtension) ] ]
         : url;
 
   loader
@@ -122,8 +122,8 @@ function amiViewer(url, rawExtension, divId) {
       window.hideMessage();
     })
     .catch(function(error) {
-      window.console.log('Error loading ' + name, error);
-      window.setWarningMessage('Error loading ' + name + '<br />' + error);
+      window.console.log('Error loading ' + filename, error);
+      window.setWarningMessage('Error loading ' + filename + '<br />' + error);
     });
 
   const animate = function() {

--- a/vip-visualization/src/main/java/fr/insalyon/creatis/vip/visualization/client/bean/VisualizationItem.java
+++ b/vip-visualization/src/main/java/fr/insalyon/creatis/vip/visualization/client/bean/VisualizationItem.java
@@ -35,34 +35,24 @@ import com.google.gwt.user.client.rpc.IsSerializable;
 
 /** @author Tristan Glatard */
 public class VisualizationItem implements IsSerializable{
-    String URL;
-    String localPath;
+    private String lfn;
 
     // Extension of raw file if url is a mhd file.  Empty string otherwise.
-    String extension;
+    private String extension;
 
     public VisualizationItem() {}
 
-    public VisualizationItem(String URL, String localPath, String extension) {
-        this.URL = URL;
-        this.localPath = localPath;
+    public VisualizationItem(String lfn, String extension) {
+        this.lfn = lfn;
         this.extension = extension;
     }
 
-    public String getURL() {
-        return URL;
+    public String getLfn() {
+        return lfn;
     }
 
-    public void setURL(String URL) {
-        this.URL = URL;
-    }
-
-    public String getLocalPath() {
-        return localPath;
-    }
-
-    public void setLocalPath(String localPath) {
-        this.localPath = localPath;
+    public void setLfn(String lfn) {
+        this.lfn = lfn;
     }
 
     public String getExtension() {

--- a/vip-visualization/src/main/java/fr/insalyon/creatis/vip/visualization/client/view/AbstractViewTab.java
+++ b/vip-visualization/src/main/java/fr/insalyon/creatis/vip/visualization/client/view/AbstractViewTab.java
@@ -31,6 +31,7 @@
  */
 package fr.insalyon.creatis.vip.visualization.client.view;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.smartgwt.client.widgets.Canvas;
 import com.smartgwt.client.widgets.tab.Tab;
@@ -78,6 +79,10 @@ public abstract class AbstractViewTab extends Tab {
                     displayFile(result);
                 }
             });
+    }
+
+    protected String getFileUrl(String lfn) {
+        return GWT.getModuleBaseURL() + "/filedownloadservice?path=" + lfn;
     }
 
     public abstract void displayFile(VisualizationItem url);

--- a/vip-visualization/src/main/java/fr/insalyon/creatis/vip/visualization/client/view/AbstractViewTab.java
+++ b/vip-visualization/src/main/java/fr/insalyon/creatis/vip/visualization/client/view/AbstractViewTab.java
@@ -40,8 +40,6 @@ import fr.insalyon.creatis.vip.visualization.client.bean.VisualizationItem;
 import fr.insalyon.creatis.vip.visualization.client.rpc.VisualizationService;
 import fr.insalyon.creatis.vip.visualization.client.rpc.VisualizationServiceAsync;
 
-import java.nio.file.Paths;
-
 /** @author Tristan Glatard */
 public abstract class AbstractViewTab extends Tab {
 
@@ -84,7 +82,7 @@ public abstract class AbstractViewTab extends Tab {
     }
 
     protected String getFileUrl(String lfn) {
-        String filename = Paths.get(lfn).getFileName().toString();
+        String filename = lfn.substring(lfn.lastIndexOf('/') + 1);
         // filename param is needed for ami to determine type
         return GWT.getModuleBaseURL() +
                 "/filedownloadservice" +

--- a/vip-visualization/src/main/java/fr/insalyon/creatis/vip/visualization/client/view/AbstractViewTab.java
+++ b/vip-visualization/src/main/java/fr/insalyon/creatis/vip/visualization/client/view/AbstractViewTab.java
@@ -40,6 +40,8 @@ import fr.insalyon.creatis.vip.visualization.client.bean.VisualizationItem;
 import fr.insalyon.creatis.vip.visualization.client.rpc.VisualizationService;
 import fr.insalyon.creatis.vip.visualization.client.rpc.VisualizationServiceAsync;
 
+import java.nio.file.Paths;
+
 /** @author Tristan Glatard */
 public abstract class AbstractViewTab extends Tab {
 
@@ -82,7 +84,12 @@ public abstract class AbstractViewTab extends Tab {
     }
 
     protected String getFileUrl(String lfn) {
-        return GWT.getModuleBaseURL() + "/filedownloadservice?path=" + lfn;
+        String filename = Paths.get(lfn).getFileName().toString();
+        // filename param is needed for ami to determine type
+        return GWT.getModuleBaseURL() +
+                "/filedownloadservice" +
+                "?path=" + lfn +
+                "&filename=" + filename;
     }
 
     public abstract void displayFile(VisualizationItem url);

--- a/vip-visualization/src/main/java/fr/insalyon/creatis/vip/visualization/client/view/AbstractViewTab.java
+++ b/vip-visualization/src/main/java/fr/insalyon/creatis/vip/visualization/client/view/AbstractViewTab.java
@@ -32,6 +32,7 @@
 package fr.insalyon.creatis.vip.visualization.client.view;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.http.client.URL;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.smartgwt.client.widgets.Canvas;
 import com.smartgwt.client.widgets.tab.Tab;
@@ -39,6 +40,9 @@ import fr.insalyon.creatis.vip.core.client.view.layout.Layout;
 import fr.insalyon.creatis.vip.visualization.client.bean.VisualizationItem;
 import fr.insalyon.creatis.vip.visualization.client.rpc.VisualizationService;
 import fr.insalyon.creatis.vip.visualization.client.rpc.VisualizationServiceAsync;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 
 /** @author Tristan Glatard */
 public abstract class AbstractViewTab extends Tab {
@@ -86,7 +90,7 @@ public abstract class AbstractViewTab extends Tab {
         // filename param is needed for ami to determine type
         return GWT.getModuleBaseURL() +
                 "/filedownloadservice" +
-                "?path=" + lfn +
+                "?path=" + URL.encode(lfn) +
                 "&filename=" + filename;
     }
 

--- a/vip-visualization/src/main/java/fr/insalyon/creatis/vip/visualization/client/view/AmiImageViewTab.java
+++ b/vip-visualization/src/main/java/fr/insalyon/creatis/vip/visualization/client/view/AmiImageViewTab.java
@@ -34,7 +34,7 @@ package fr.insalyon.creatis.vip.visualization.client.view;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.smartgwt.client.widgets.HTMLPane;
 import fr.insalyon.creatis.vip.visualization.client.bean.VisualizationItem;
-import java.util.logging.Level;
+
 import java.util.logging.Logger;
 
 public class AmiImageViewTab extends AbstractViewTab {
@@ -88,13 +88,13 @@ public class AmiImageViewTab extends AbstractViewTab {
 
     @Override
     public void displayFile(VisualizationItem item) {
-        String name = item.getURL();
-        amiJsViewer = showAmiImage(name, item.getExtension(), divId);
+        String url = getFileUrl(item.getLfn());
+        amiJsViewer = showAmiImage(url, item.getExtension(), divId);
     }
 
     public native JavaScriptObject
-        showAmiImage(String filename, String extension, String divId) /*-{
-        return $wnd.amiViewer(filename, extension, divId);
+        showAmiImage(String url, String extension, String divId) /*-{
+        return $wnd.amiViewer(url, extension, divId);
     }-*/;
 
     public native void resizeCanvas(JavaScriptObject amiViewer) /*-{

--- a/vip-visualization/src/main/java/fr/insalyon/creatis/vip/visualization/client/view/BrainBrowserViewTab.java
+++ b/vip-visualization/src/main/java/fr/insalyon/creatis/vip/visualization/client/view/BrainBrowserViewTab.java
@@ -62,10 +62,19 @@ public class BrainBrowserViewTab extends AbstractViewTab {
 
     @Override
     public void displayFile(VisualizationItem item) {
-        showBrainBrowser(getFileUrl(item.getLfn()));
+        String url = getFileUrl(item.getLfn());
+        if (item.getLfn().endsWith(".asc")) {
+            showBrainBrowserForAsc(url);
+        } else {
+            showBrainBrowserForObj(url);
+        }
     }
 
-    public native void showBrainBrowser(String fileUrl) /*-{
-           $wnd.$("#brain-browser").load("https://brainbrowser.cbrain.mcgill.ca/surface-viewer-widget?version=2.1.1&nothreejs=true&model="+fileUrl);
+    public native void showBrainBrowserForObj(String fileUrl) /*-{
+           $wnd.$("#brain-browser").load("https://brainbrowser.cbrain.mcgill.ca/surface-viewer-widget?version=2.5.2&model="+fileUrl);
+    }-*/;
+
+    public native void showBrainBrowserForAsc(String fileUrl) /*-{
+           $wnd.$("#brain-browser").load("https://brainbrowser.cbrain.mcgill.ca/surface-viewer-widget?version=2.5.2&model="+fileUrl+"&format=freesurferasc");
     }-*/;
 }

--- a/vip-visualization/src/main/java/fr/insalyon/creatis/vip/visualization/client/view/BrainBrowserViewTab.java
+++ b/vip-visualization/src/main/java/fr/insalyon/creatis/vip/visualization/client/view/BrainBrowserViewTab.java
@@ -62,10 +62,10 @@ public class BrainBrowserViewTab extends AbstractViewTab {
 
     @Override
     public void displayFile(VisualizationItem item) {
-        showBrainBrowser(item.getURL());
+        showBrainBrowser(getFileUrl(item.getLfn()));
     }
 
-    public native void showBrainBrowser(String fileName) /*-{
-           $wnd.$("#brain-browser").load("https://brainbrowser.cbrain.mcgill.ca/surface-viewer-widget?version=2.1.1&nothreejs=true&model="+fileName);
+    public native void showBrainBrowser(String fileUrl) /*-{
+           $wnd.$("#brain-browser").load("https://brainbrowser.cbrain.mcgill.ca/surface-viewer-widget?version=2.1.1&nothreejs=true&model="+fileUrl);
     }-*/;
 }

--- a/vip-visualization/src/main/java/fr/insalyon/creatis/vip/visualization/server/rpc/VisualizationServiceImpl.java
+++ b/vip-visualization/src/main/java/fr/insalyon/creatis/vip/visualization/server/rpc/VisualizationServiceImpl.java
@@ -81,7 +81,6 @@ public class VisualizationServiceImpl extends AbstractRemoteServiceServlet
             User user = getSessionUser();
             return visualizationBusiness.getVisualizationItemFromLFN(
                 lfn,
-                this.getServletContext().getRealPath("."),
                 user);
         } catch (BusinessException | CoreException ex) {
             throw new VisualizationException(ex);


### PR DESCRIPTION
Deal with #205, rewriting all the parts where there are downloads :
- file and folder downloads in file transfers
- file downloads in api
- file downloads in execution view (inputs / outputs / stdout / stderr)
- visualization
- boutiques descriptor download for application import
- boutiques descriptor download for publication with boutiques
- workflow downloads for launch

Now, all is uniform : everything is downloaded on the same grida folder in a coherent way, and it is hidden to business.
Also, as visualization needs a downoad url, a new way to download a file by its lfn has been added.