### PR TITLE
improve jackson mapper bean creation

### DIFF
--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/SpringSecurityConfig.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/SpringSecurityConfig.java
@@ -31,23 +31,20 @@
  */
 package fr.insalyon.creatis.vip.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import fr.insalyon.creatis.vip.api.CarminProperties;
 import fr.insalyon.creatis.vip.api.security.SpringCompatibleUser;
-import fr.insalyon.creatis.vip.api.security.apikey.*;
+import fr.insalyon.creatis.vip.api.security.apikey.ApikeyAuthenticationEntryPoint;
+import fr.insalyon.creatis.vip.api.security.apikey.ApikeyAuthentificationConfigurer;
 import fr.insalyon.creatis.vip.core.client.bean.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.Environment;
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
-import org.springframework.security.config.annotation.web.configuration.*;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.firewall.DefaultHttpFirewall;
-import org.springframework.security.web.firewall.StrictHttpFirewall;
 
 import java.util.function.Supplier;
 
@@ -66,11 +63,15 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
 
     // authentication done by bean LimitigDaoAuthenticationProvider
 
-    @Autowired
-    private ApikeyAuthenticationEntryPoint apikeyAuthenticationEntryPoint;
+    private final ApikeyAuthenticationEntryPoint apikeyAuthenticationEntryPoint;
+
+    private final Environment env;
 
     @Autowired
-    private Environment env;
+    public SpringSecurityConfig(ApikeyAuthenticationEntryPoint apikeyAuthenticationEntryPoint, Environment env) {
+        this.apikeyAuthenticationEntryPoint = apikeyAuthenticationEntryPoint;
+        this.env = env;
+    }
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -108,11 +109,6 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
                     (SpringCompatibleUser) authentication.getPrincipal();
             return springCompatibleUser.getVipUser();
         };
-    }
-
-    @Bean
-    public ObjectMapper objectMapper() {
-        return Jackson2ObjectMapperBuilder.json().build();
     }
 
     /*

--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/SpringWebConfig.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/SpringWebConfig.java
@@ -31,6 +31,7 @@
  */
 package fr.insalyon.creatis.vip.api;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import fr.insalyon.creatis.vip.api.business.VipConfigurer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -43,6 +44,7 @@ import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertiesPropertySource;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.support.ResourcePropertySource;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.web.servlet.config.annotation.*;
 
 import java.io.IOException;
@@ -102,4 +104,8 @@ public class SpringWebConfig implements WebMvcConfigurer {
         registry.addInterceptor(vipConfigurer);
     }
 
+    @Bean
+    public ObjectMapper objectMapper() {
+        return Jackson2ObjectMapperBuilder.json().build();
+    }
 }

--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/security/apikey/ApikeyAuthenticationEntryPoint.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/security/apikey/ApikeyAuthenticationEntryPoint.java
@@ -56,6 +56,7 @@ public class ApikeyAuthenticationEntryPoint implements AuthenticationEntryPoint 
 
     private final ObjectMapper objectMapper;
 
+    @Autowired
     public ApikeyAuthenticationEntryPoint(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }


### PR DESCRIPTION
Correct a spring initialization failure that can happen in some case spring creates some beans in a wrong order.