### PR TITLE
Strip_Extention_Boutiques

### DIFF
--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/bean/boutiquesTools/BoutiquesOutputFile.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/bean/boutiquesTools/BoutiquesOutputFile.java
@@ -49,7 +49,7 @@ public class BoutiquesOutputFile implements IsSerializable {
     private boolean list;
     private boolean optional;
     private String commandLineFlag;
-    private Set<String> pathTemplateStrippedExtensions;
+    private String pathTemplateStrippedExtensionsString;
     
    
     public String getId() {
@@ -84,6 +84,10 @@ public class BoutiquesOutputFile implements IsSerializable {
         return commandLineFlag;
     }
 
+    public String getPathTemplateStrippedExtensionsString() {
+	    return pathTemplateStrippedExtensionsString;
+	}
+
     public void setId(String id) {
         this.id = id;
     }
@@ -116,12 +120,7 @@ public class BoutiquesOutputFile implements IsSerializable {
         this.commandLineFlag = commandLineFlag;
     }
 
-    //getter
-	public Set<String> getPathTemplateStrippedExtensions() {
-		return pathTemplateStrippedExtensions;
-	}
-	//setter
-	public void setPathTemplateStrippedExtensions(Set<String> pathTemplateStrippedExtensions) {
-		this.pathTemplateStrippedExtensions = pathTemplateStrippedExtensions;
+        public void setPathTemplateStrippedExtensionsString(String pathTemplateStrippedExtensionsString) {
+	    this.pathTemplateStrippedExtensionsString = pathTemplateStrippedExtensionsString;
 	}
 }

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/bean/boutiquesTools/BoutiquesOutputFile.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/bean/boutiquesTools/BoutiquesOutputFile.java
@@ -31,6 +31,8 @@
  */
 package fr.insalyon.creatis.vip.application.client.bean.boutiquesTools;
 
+import java.util.Set;
+
 import com.google.gwt.user.client.rpc.IsSerializable;
 
 /**
@@ -47,7 +49,9 @@ public class BoutiquesOutputFile implements IsSerializable {
     private boolean list;
     private boolean optional;
     private String commandLineFlag;
-
+    private Set<String> pathTemplateStrippedExtensions;
+    
+   
     public String getId() {
         return id;
     }
@@ -112,4 +116,12 @@ public class BoutiquesOutputFile implements IsSerializable {
         this.commandLineFlag = commandLineFlag;
     }
 
+    //getter
+	public Set<String> getPathTemplateStrippedExtensions() {
+		return pathTemplateStrippedExtensions;
+	}
+	//setter
+	public void setPathTemplateStrippedExtensions(Set<String> pathTemplateStrippedExtensions) {
+		this.pathTemplateStrippedExtensions = pathTemplateStrippedExtensions;
+	}
 }

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/boutiquesParsing/BoutiquesParser.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/boutiquesParsing/BoutiquesParser.java
@@ -222,7 +222,7 @@ public class BoutiquesParser extends AbstractJsonParser{
         bof.setList(getBooleanValue(outputFile, "list", true));
         bof.setOptional(getBooleanValue(outputFile, "optional", true));
         Set<String> stripExtn=getArrayValueAsStringSet(outputFile, "path-template-stripped-extensions", true);
-        bof.setPathTemplateStrippedExtensions(stripExtn);
+        bof.setPathTemplateStrippedExtensionsString(String.join("", stripExtn));
         String commandLineFlag = getStringValue(outputFile, "command-line-flag", true);
         commandLineFlag = commandLineFlag == null ? "" : commandLineFlag;
         bof.setCommandLineFlag(commandLineFlag);

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/boutiquesParsing/BoutiquesParser.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/boutiquesParsing/BoutiquesParser.java
@@ -222,7 +222,7 @@ public class BoutiquesParser extends AbstractJsonParser{
         bof.setList(getBooleanValue(outputFile, "list", true));
         bof.setOptional(getBooleanValue(outputFile, "optional", true));
         Set<String> stripExtn=getArrayValueAsStringSet(outputFile, "path-template-stripped-extensions", true);
-        bof.setPathTemplateStrippedExtensionsString(String.join("", stripExtn));
+        bof.setPathTemplateStrippedExtensionsString(String.join(",", stripExtn));
         String commandLineFlag = getStringValue(outputFile, "command-line-flag", true);
         commandLineFlag = commandLineFlag == null ? "" : commandLineFlag;
         bof.setCommandLineFlag(commandLineFlag);

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/boutiquesParsing/BoutiquesParser.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/boutiquesParsing/BoutiquesParser.java
@@ -4,7 +4,7 @@ import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONParser;
 import fr.insalyon.creatis.vip.application.client.bean.boutiquesTools.*;
-
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -221,6 +221,8 @@ public class BoutiquesParser extends AbstractJsonParser{
         bof.setPathTemplate(getStringValue(outputFile, "path-template", true));
         bof.setList(getBooleanValue(outputFile, "list", true));
         bof.setOptional(getBooleanValue(outputFile, "optional", true));
+        Set<String> stripExtn=getArrayValueAsStringSet(outputFile, "path-template-stripped-extensions", true);
+        bof.setPathTemplateStrippedExtensions(stripExtn);
         String commandLineFlag = getStringValue(outputFile, "command-line-flag", true);
         commandLineFlag = commandLineFlag == null ? "" : commandLineFlag;
         bof.setCommandLineFlag(commandLineFlag);

--- a/vip-portal/src/main/resources/vm/gasw.vm
+++ b/vip-portal/src/main/resources/vm/gasw.vm
@@ -31,9 +31,13 @@
 #set ($value=$value.replace($input.getValueKey(),"$na$i"))
 #end
 #end
-      <template value="$prefix1$dir1/$na1/$value$options1" />
-      <access type="LFN"/>
-    </output>
+    <template value="$prefix1$dir1/$na1/$value$options1"
+#if(($outputFile.PathTemplateStrippedExtensions) && ($outputFile.PathTemplateStrippedExtensions != []))
+    strip-extension="$outputFile.getPathTemplateStrippedExtensions()"
 #end
-  </executable>
+/>
+<access type="LFN"/>
+</output>
+#end
+</executable>
 </description>

--- a/vip-portal/src/main/resources/vm/gasw.vm
+++ b/vip-portal/src/main/resources/vm/gasw.vm
@@ -32,7 +32,7 @@
 #end
 #end
     <template value="$prefix1$dir1/$na1/$value$options1"
-#if(($outputFile.PathTemplateStrippedExtensions) && ($outputFile.PathTemplateStrippedExtensions != []))
+#if(($outputFile.getPathTemplateStrippedExtensions()) && ($outputFile.getPathTemplateStrippedExtensions() != []))
     strip-extension="$outputFile.getPathTemplateStrippedExtensions()"
 #end
 />

--- a/vip-portal/src/main/resources/vm/gasw.vm
+++ b/vip-portal/src/main/resources/vm/gasw.vm
@@ -32,8 +32,8 @@
 #end
 #end
     <template value="$prefix1$dir1/$na1/$value$options1"
-#if(($outputFile.getPathTemplateStrippedExtensions()) && ($outputFile.getPathTemplateStrippedExtensions() != []))
-    strip-extension="$outputFile.getPathTemplateStrippedExtensions()"
+#if(($outputFile.getPathTemplateStrippedExtensionsString()) && ($outputFile.getPathTemplateStrippedExtensionsString() != ""))
+    strip-extensions="$outputFile.getPathTemplateStrippedExtensionsString()"
 #end
 />
 <access type="LFN"/>


### PR DESCRIPTION
1. Boutiques supports stripping the extension of the file. ('path-template-stripped-extensions')

2. But this feature of the boutique schema is not functioning on VIP.

3. It is to remove the extension of the path template (similar to baseline command in bash).

4. descriptor -> xml Descriptor key : Mapped to Java class (BoutiquesOutputFile) 2 variables , one for capturing strip extn values and another boolean variable which decide the descriptor contains strip extn or not and defined getter setters for those two variables To set value of those 2 variables in BoutiquesOutputFile : Java class : BoutiquesParser method : parseBoutiquesOutputFile and in gasw.vm : to add strip extn value in template tag based on condition

5. xml -> file creation with /without strip extn GaswParser : to read strip extn value from xml. if it’s not present in xml then create empty object of Set
    GaswOutputTemplatePart : created a varaible to store value to srip extensions(since there can be multiple extensions we are using Set stripExtensions)
    GaswParser : wherever we create object of GaswOutputTemplatePart class, we pass strip extension value to the constructor.
    GaswParser: method parseOutputTemplat: Inside case : Name , we replace strpextension with blank.(removing strip extensions from i/p file)