### PR TITLE
Cvmfs

### DIFF
--- a/vip-portal/src/main/resources/vm/wrapper.vm
+++ b/vip-portal/src/main/resources/vm/wrapper.vm
@@ -161,7 +161,16 @@ fi
 echo "import sys; sys.setdefaultencoding(\"UTF8\")" > sitecustomize.py
 #creating a temporary directory for bindmount /tmp of containers
 mkdir -p tmp
-PYTHONPATH=".:$PYTHONPATH" $BOSHEXEC exec launch $JSONFILE input_param_file.json -v $PWD/../cache:$PWD/../cache -v $PWD/tmp:/tmp
+#TMP_FOLDER is created differently for execution on GRID and execution on LOCAL
+#TMP of the container is bind mounted on TMP_FOLDER to avoid creating temporary files on container.
+TMP_FOLDER=tmp_$(basename $PWD)
+#if($isRunOnGrid == false)
+TMP_FOLDER=/tmp/$TMP_FOLDER
+#else  
+TMP_FOLDER=../$TMP_FOLDER
+#end
+
+PYTHONPATH=".:$PYTHONPATH" $BOSHEXEC exec launch $JSONFILE input_param_file.json -v $PWD/../cache:$PWD/../cache -v $TMP_FOLDER:/tmp
 
 if [ $? != 0 ]
 then

--- a/vip-portal/src/main/resources/vm/wrapper.vm
+++ b/vip-portal/src/main/resources/vm/wrapper.vm
@@ -159,7 +159,9 @@ fi
 # Change PYTHONPATH to make all strings unicode by default in python2 (as in python3)
 # Otherwise `bosh exec` fails on any non-ascii characters in outputs
 echo "import sys; sys.setdefaultencoding(\"UTF8\")" > sitecustomize.py
-PYTHONPATH=".:$PYTHONPATH" $BOSHEXEC exec launch $JSONFILE input_param_file.json -v $PWD/../cache:$PWD/../cache
+#creating a temporary directory for bindmount /tmp of containers
+mkdir -p tmp
+PYTHONPATH=".:$PYTHONPATH" $BOSHEXEC exec launch $JSONFILE input_param_file.json -v $PWD/../cache:$PWD/../cache -v $PWD/tmp:/tmp
 
 if [ $? != 0 ]
 then


### PR DESCRIPTION
Some CVMFS containers tries create temporary files inside the container, which is prevented by cvmfs due to read-only access to the storage elements, resulting in failure of the execution (e.g BratsPipeline)

1. Make a directory named tmp in $PWD and bind mount it on the container to avoid any creation of temporary files in case of a cvmfs container.
2. For the containers pulled from docker-hub (or similar repositories), should also use the $PWD/tmp folder