### PR TITLE
Fixing typos in README.md and privacypolicy.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,19 @@ The VIP logo was designed by Max Langer under the [CC BY-NC-SA license](https://
 git config --global user.name "Jeanne Tartempion"                  # not "tartempion" or "jtartempion" or "root"
 git config --global user.email "jeanne.tartempion@university.fr"   # not "root@localhost"
 ```
+
 1. Developments are made in forks from the base repository. Developments lead to pull-requests that are merged by the owner(s) of the base repository.
-2. Starting from release 1.15, we adopt the branching model described [here](http://nvie.com/posts/a-successful-git-branching-model). 
-3. When working on a new feature: 
+
+2. Starting from release 1.15, we adopt the branching model described [here](http://nvie.com/posts/a-successful-git-branching-model).
+
+3. When working on a new feature:
 * In your fork, create a new feature branch from the development branch:
 ```
 git checkout -b new_feature develop
 ```
-You may name your branch anything except master, develop, release-*, or hotfix-*
-3. When feature development is finished:
+* You may name your branch anything except `master`, `develop`, `release-*`, or `hotfix-*`.
+
+4. When feature development is finished:
 * Push your commits to Github (your fork).
 * Make a pull request to merge feature branch (in your fork) to development branch (in the base repository).
 

--- a/vip-portal/src/main/webapp/documentation/privacypolicy.html
+++ b/vip-portal/src/main/webapp/documentation/privacypolicy.html
@@ -45,8 +45,8 @@
 
   <h2>Third parties to whom personal data is disclosed</h2>
   No personal data is disclosed to third parties.
-  Statistics (deprived of any personal information) are shared with parterns, stakeholders and the community.
-  Technical stuff managing the various services used within VIP may have access to some of the pieces of information described in sections A and B.
+  Statistics (deprived of any personal information) are shared with partners, stakeholders and the community.
+  Technical staff managing the various services used within VIP may have access to some of the pieces of information described in sections A and B.
 
   <h2>How to access, rectify and delete the personal data and object to its processing</h2>
   Contact VIP support team at vip-support@creatis.insa-lyon.fr


### PR DESCRIPTION
This PR fixes minor readability issues in two publicly visible documents :
- Just two words changed in privacypolicy.html : [3fc0bd72ba](https://github.com/ngeorges-cnrs/VIP-portal/commit/3fc0bd72ba4de43375d4fb7eadea24874eb25bc9)
- A few changes in README.md for proper web rendering of the "Development guidelines" section : see [2f8044683a](https://github.com/ngeorges-cnrs/VIP-portal/commit/2f8044683aaa447f7c3c0a7e0e2416fb38be00bc) commit message for detail. I made two minor arguable choices :
  - In step 3, we could either add a second bullet point as I did, or remove bullet points entirely.
  - Technically, a blank line is only needed between steps 3 and 4, but I also added such a line after each step of the section, to make the raw content of README.md more consistent, and bullet-points proof.
