### PR TITLE
Fix build warnings

### DIFF
--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/SpringWebConfig.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/SpringWebConfig.java
@@ -64,15 +64,6 @@ public class SpringWebConfig implements WebMvcConfigurer {
     }
 
     @Override
-    public void configurePathMatch(PathMatchConfigurer configurer) {
-        // Otherwise all that follow a dot in an URL is considered an extension and removed
-        // It's a problem for URL like "/pipelines/gate/3.2
-        // The below will become the default values in Spring 5.3
-        // Safe to use in 5.2 as long as disabling pattern match
-        configurer.setUseSuffixPatternMatch(false);
-    }
-
-    @Override
     public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
         // necessary in the content negotiation stuff of carmin data
         // this should be the default in Spring 5.3 and may be removed then

--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/DataApiBusiness.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/DataApiBusiness.java
@@ -52,6 +52,7 @@ import fr.insalyon.creatis.vip.datamanager.server.business.LFCPermissionBusiness
 import fr.insalyon.creatis.vip.datamanager.server.business.TransferPoolBusiness;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.input.ReaderInputStream;
+import org.apache.commons.io.input.ReaderInputStream.Builder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -391,8 +392,12 @@ public class DataApiBusiness {
     private void writeFileFromBase64(String base64Content, String localFilePath) throws ApiException {
         Base64.Decoder decoder = Base64.getDecoder();
         StringReader stringReader = new StringReader(base64Content);
-        InputStream inputStream = new ReaderInputStream(stringReader, StandardCharsets.UTF_8);
-        try (InputStream base64InputStream = decoder.wrap(inputStream)) {
+        try {
+            InputStream inputStream = ReaderInputStream.builder()
+                    .setReader(new StringReader(base64Content))
+                    .setCharset(StandardCharsets.UTF_8)
+                    .get();
+            InputStream base64InputStream = decoder.wrap(inputStream);
             Files.copy(base64InputStream, Paths.get(localFilePath));
         } catch (IOException e) {
             logger.error("Error writing base64 file in {}", localFilePath, e);

--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/PipelineBusiness.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/PipelineBusiness.java
@@ -59,6 +59,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.ArrayList;

--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/PipelineBusiness.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/PipelineBusiness.java
@@ -59,7 +59,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
-import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.ArrayList;

--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/security/oidc/OidcResolver.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/security/oidc/OidcResolver.java
@@ -73,6 +73,7 @@ public class OidcResolver {
 
     // Create authorities list from jwt claims.
     // Parsing realm_access.roles or resource_access.<resourceName>.roles is Keycloak-specific.
+    @SuppressWarnings("unchecked")
     private List<GrantedAuthority> parseAuthorities(User user, Jwt jwt) {
         List<String> roles = new ArrayList<>(); // default to no roles
         // At this point, jwt has already been verified by Spring resource server, so we assume the issuer is known (server != null).

--- a/vip-api/src/test/java/fr/insalyon/creatis/vip/api/data/AuthenticationInfoTestUtils.java
+++ b/vip-api/src/test/java/fr/insalyon/creatis/vip/api/data/AuthenticationInfoTestUtils.java
@@ -51,6 +51,7 @@ public class AuthenticationInfoTestUtils {
         authenticationInfoSuppliers = getAuthenticationInfoSuppliers();
     }
 
+    @SuppressWarnings("unchecked")
     public static Map<String, Function> getAuthenticationInfoSuppliers() {
         return JsonCustomObjectMatcher.formatSuppliers(
                 Arrays.asList("httpHeader", "httpHeaderValue"),

--- a/vip-api/src/test/java/fr/insalyon/creatis/vip/api/data/ErrorCodeAndMessageTestUtils.java
+++ b/vip-api/src/test/java/fr/insalyon/creatis/vip/api/data/ErrorCodeAndMessageTestUtils.java
@@ -53,6 +53,7 @@ public class ErrorCodeAndMessageTestUtils {
         errorCodeAndMessageSuppliers = getErrorCodeAndMessageSuppliers();
     }
 
+    @SuppressWarnings("unchecked")
     public static Map<String,Function> getErrorCodeAndMessageSuppliers() {
         return JsonCustomObjectMatcher.formatSuppliers(
                 Arrays.asList("errorCode", "errorMessage"),

--- a/vip-api/src/test/java/fr/insalyon/creatis/vip/api/data/ExecutionTestUtils.java
+++ b/vip-api/src/test/java/fr/insalyon/creatis/vip/api/data/ExecutionTestUtils.java
@@ -158,6 +158,7 @@ public class ExecutionTestUtils {
         return newSimulation;
     }
 
+    @SuppressWarnings("unchecked")
     public static Map<String,Function> getExecutionSuppliers() {
         return JsonCustomObjectMatcher.formatSuppliers(
                 Arrays.asList(

--- a/vip-api/src/test/java/fr/insalyon/creatis/vip/api/data/PathTestUtils.java
+++ b/vip-api/src/test/java/fr/insalyon/creatis/vip/api/data/PathTestUtils.java
@@ -178,6 +178,8 @@ public class PathTestUtils {
         return pathProperties;
     }
 
+    // [WARNING] VIP-portal/vip-api/src/test/java/fr/insalyon/creatis/vip/api/data/PathTestUtils.java:[182,55] unchecked generic array creation for varargs parameter of type java.util.function.Function<fr.insalyon.creatis.vip.api.model.PathProperties,?>[]
+    @SuppressWarnings("unchecked")
     private static Map<String, Function> getPathSuppliers() {
         return JsonCustomObjectMatcher.formatSuppliers(
                 Arrays.asList("path", "lastModificationDate", "isDirectory", "exists",

--- a/vip-api/src/test/java/fr/insalyon/creatis/vip/api/data/PipelineTestUtils.java
+++ b/vip-api/src/test/java/fr/insalyon/creatis/vip/api/data/PipelineTestUtils.java
@@ -49,6 +49,7 @@ import java.util.function.Function;
 /**
  * Created by abonnet on 8/3/16.
  */
+@SuppressWarnings("unchecked")
 public class PipelineTestUtils {
 
     public static final Map<String,Function> pipelineSuppliers;

--- a/vip-api/src/test/java/fr/insalyon/creatis/vip/api/rest/itest/processing/ExecutionControllerIT.java
+++ b/vip-api/src/test/java/fr/insalyon/creatis/vip/api/rest/itest/processing/ExecutionControllerIT.java
@@ -98,11 +98,12 @@ public class ExecutionControllerIT extends BaseWebSpringIT {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void shouldListExecutions() throws Exception {
-        when(workflowDAO.get(eq(simulation1.getID()))).thenReturn(w1, null);
-        when(workflowDAO.get(eq(simulation2.getID()))).thenReturn(w2, null);
+        when(workflowDAO.get(eq(simulation1.getID()))).thenReturn(w1, (Workflow) null);
+        when(workflowDAO.get(eq(simulation2.getID()))).thenReturn(w2, (Workflow) null);
         when(workflowDAO.get(Collections.singletonList(baseUser1.getFullName()), null, null, null, null, null, null))
-                .thenReturn(Arrays.asList(w1, w2), null);
+                .thenReturn(Arrays.asList(w1, w2), (List<Workflow>) null);
 
         // perform a getWorkflows()
         mockMvc.perform(
@@ -120,9 +121,10 @@ public class ExecutionControllerIT extends BaseWebSpringIT {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void shouldCountExecutions() throws Exception {
         when(workflowDAO.get(Collections.singletonList(baseUser1.getFullName()), null, null, null, null, null, null))
-                .thenReturn(Arrays.asList(w1, w2), null);
+                .thenReturn(Arrays.asList(w1, w2), (List<Workflow>) null);
 
         // perform a getWorkflows()
         mockMvc.perform(
@@ -329,12 +331,13 @@ public class ExecutionControllerIT extends BaseWebSpringIT {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void shouldGetExecution2Results() throws Exception {
         String resultPath = "/root/user/user1/path/to/result.res";
 
-        when(workflowDAO.get(eq(simulation2.getID()))).thenReturn(w2, null);
+        when(workflowDAO.get(eq(simulation2.getID()))).thenReturn(w2, (Workflow) null);
         Output output = new Output(new OutputID("workflowID", resultPath, "processor"), DataType.URI, "port");
-        when(outputDAO.get(eq(simulation2.getID()))).thenReturn(Arrays.asList(output), null);
+        when(outputDAO.get(eq(simulation2.getID()))).thenReturn(Arrays.asList(output), (List<Output>) null);
 
         Mockito.when(server.getDataManagerUsersHome()).thenReturn("/root/user");
         Mockito.when(gridaClient.exist(resultPath)).thenReturn(true);
@@ -365,6 +368,7 @@ public class ExecutionControllerIT extends BaseWebSpringIT {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testInitGwendiaExecution() throws Exception
     {
         String appName = "test application", groupName = "testGroup", className = "testClass", versionName = "4.2";
@@ -444,6 +448,7 @@ public class ExecutionControllerIT extends BaseWebSpringIT {
 
     // the difference (at the moment) is that with moteurLite the optional and absent parameters are not included
     @Test
+    @SuppressWarnings("unchecked")
     public void testInitBoutiquesExecution() throws Exception
     {
         String appName = "test application", groupName = "testGroup", className = "testClass", versionName = "4.2";

--- a/vip-api/src/test/java/fr/insalyon/creatis/vip/api/tools/spring/JsonCustomObjectMatcher.java
+++ b/vip-api/src/test/java/fr/insalyon/creatis/vip/api/tools/spring/JsonCustomObjectMatcher.java
@@ -65,6 +65,7 @@ public class JsonCustomObjectMatcher<T> extends TypeSafeDiagnosingMatcher<Map<St
         this(expectedBean, suppliers, new HashMap<>());
     }
 
+    @SuppressWarnings("unchecked")
     public JsonCustomObjectMatcher(T expectedBean,
                                    Map<String, Function> suppliers,
                                    Map<Class,Map<String,Function>> suppliersRegistry) {
@@ -88,6 +89,7 @@ public class JsonCustomObjectMatcher<T> extends TypeSafeDiagnosingMatcher<Map<St
         nonNullPropertiesCountMatcher = equalTo(propertyMatchers.size());
     }
 
+    @SuppressWarnings("unchecked")
     private static Matcher<?> getGenericMatcher(
             Object expectedValue,
             Map<Class, Map<String, Function>> suppliersRegistry) {
@@ -133,6 +135,7 @@ public class JsonCustomObjectMatcher<T> extends TypeSafeDiagnosingMatcher<Map<St
         }
     }
 
+    @SuppressWarnings("unchecked")
     private static Matcher<Map<String, ?>> getCustomObjectMatcherFromRegistry(
             Object o,
             Map<Class, Map<String, Function>> suppliersRegistry) {
@@ -157,6 +160,7 @@ public class JsonCustomObjectMatcher<T> extends TypeSafeDiagnosingMatcher<Map<St
         return new JsonCustomObjectMatcher<T>(expectedBean, suppliers, suppliersRegistry);
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> Map<String, Function> formatSuppliers(
             List<String> mapKeys, Function<T,?>... suppliers) {
         if (mapKeys.size() != suppliers.length) {
@@ -207,6 +211,7 @@ public class JsonCustomObjectMatcher<T> extends TypeSafeDiagnosingMatcher<Map<St
         private final Matcher<Integer> sizeMatcher;
         private final List<Matcher<?>> mapEntriesMatchers = new ArrayList<>();
 
+        @SuppressWarnings("unchecked")
         private JsonMapMatcher(
                 Map<?, ?> expectedMap,
                 Map<Class, Map<String, Function>> suppliersRegistry) {

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/monitor/ChartsTab.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/monitor/ChartsTab.java
@@ -123,7 +123,7 @@ public class ChartsTab extends Tab {
         chartsItem.addChangedHandler(new ChangedHandler() {
             @Override
             public void onChanged(ChangedEvent event) {
-                int value = new Integer(chartsItem.getValueAsString());
+                int value = Integer.parseInt(chartsItem.getValueAsString());
                 if (value == 1 || value == 2 || value == 6) {
                     binItem.setDisabled(true);
                 } else {

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/monitor/StatsTab.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/monitor/StatsTab.java
@@ -127,7 +127,7 @@ public class StatsTab extends Tab {
 
             @Override
             public void onChanged(ChangedEvent event) {
-                int value = new Integer(chartsItem.getValueAsString());
+                int value = Integer.parseInt(chartsItem.getValueAsString());
             }
         });
 

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/monitor/StatsTab.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/monitor/StatsTab.java
@@ -123,13 +123,6 @@ public class StatsTab extends Tab {
         chartsItem.setWidth(250);
         chartsItem.setValueMap(chartsMap);
         chartsItem.setEmptyDisplayValue("Select a chart...");
-        chartsItem.addChangedHandler(new ChangedHandler() {
-
-            @Override
-            public void onChanged(ChangedEvent event) {
-                int value = Integer.parseInt(chartsItem.getValueAsString());
-            }
-        });
 
         generateButton = WidgetUtil.getIButton("Get Stats", null, new ClickHandler() {
 

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/monitor/chart/GeneralBarChart.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/monitor/chart/GeneralBarChart.java
@@ -135,7 +135,7 @@ public class GeneralBarChart extends AbstractChart {
                             max = localMax;
                         }
                         if (res.length > 4) {
-                            sum += new Integer(res[4]);
+                            sum += Integer.parseInt(res[4]);
                         }
                     }
                 }

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/ReproVipBusiness.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/ReproVipBusiness.java
@@ -316,6 +316,7 @@ public class ReproVipBusiness {
         return outputDataMap;
     }
 
+    @SuppressWarnings("unchecked")
     private Map<String, String> getOutputFilenamesFromProvenanceFile(Path provenanceFilePath) throws BusinessException {
         try {
             Map<?, ?> map = new ObjectMapper().readValue(provenanceFilePath.toFile(), Map.class);

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowBusiness.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowBusiness.java
@@ -68,6 +68,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.xml.sax.SAXException;
 
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
@@ -395,7 +396,7 @@ public class WorkflowBusiness {
             }
             return getGwendiaParser().parse(workflowPath);
 
-        } catch (SAXException | IOException ex) {
+        } catch (SAXException | ParserConfigurationException | IOException ex) {
             logger.error("Error getting application descriptor for {}/{}", applicationName, applicationVersion, ex);
             throw new BusinessException(WRONG_APPLICATION_DESCRIPTOR, ex, applicationName + "/" + applicationVersion);
         } catch (DAOException | BusinessException ex) {

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/simulation/parser/AbstractWorkflowParser.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/simulation/parser/AbstractWorkflowParser.java
@@ -39,6 +39,8 @@ import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 import org.xml.sax.helpers.XMLReaderFactory;
 
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
@@ -61,16 +63,18 @@ public abstract class AbstractWorkflowParser extends DefaultHandler {
         sources = new ArrayList<Source>();
     }
 
-    public Descriptor parse(String fileName) throws IOException, SAXException {
+    public Descriptor parse(String fileName) throws IOException, SAXException, ParserConfigurationException {
         return parse(new FileReader(fileName));
     }
 
-    public Descriptor parseString(String workflowString) throws IOException, SAXException {
+    public Descriptor parseString(String workflowString) throws IOException, SAXException, ParserConfigurationException {
         return parse(new StringReader(workflowString));
     }
 
-    private Descriptor parse(Reader workflowReader) throws IOException, SAXException {
-        reader = XMLReaderFactory.createXMLReader();
+    private Descriptor parse(Reader workflowReader) throws IOException, SAXException, ParserConfigurationException {
+        SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+        parserFactory.setNamespaceAware(true);
+        reader = parserFactory.newSAXParser().getXMLReader();
         reader.setContentHandler(this);
         reader.parse(new InputSource(workflowReader));
 

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/simulation/parser/InputM2Parser.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/simulation/parser/InputM2Parser.java
@@ -56,6 +56,9 @@ import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 import org.xml.sax.helpers.XMLReaderFactory;
 
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
+
 /**
  * Parse a m2 input file.
  *
@@ -93,13 +96,15 @@ public class InputM2Parser extends DefaultHandler {
             throws BusinessException {
 
         try {
-            XMLReader reader = XMLReaderFactory.createXMLReader();
+            SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+            parserFactory.setNamespaceAware(true);
+            XMLReader reader = parserFactory.newSAXParser().getXMLReader();
             reader.setContentHandler(this);
             reader.parse(new InputSource(new FileReader(fileName)));
 
             return inputs;
 
-        } catch (IOException | SAXException ex) {
+        } catch (IOException | SAXException | ParserConfigurationException ex) {
             logger.error("Error parsing {}", fileName, ex);
             throw new BusinessException(ex);
         }

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/simulation/parser/InputParser.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/simulation/parser/InputParser.java
@@ -45,6 +45,9 @@ import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 import org.xml.sax.helpers.XMLReaderFactory;
 
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
+
 /**
  * Parse a input file.
  *
@@ -69,13 +72,15 @@ public class InputParser extends DefaultHandler {
 
     public String parse(String fileName) throws BusinessException {
         try {
-            reader = XMLReaderFactory.createXMLReader();
+            SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+            parserFactory.setNamespaceAware(true);
+            reader = parserFactory.newSAXParser().getXMLReader();
             reader.setContentHandler(this);
             reader.parse(new InputSource(new FileReader(fileName)));
 
             return inputs.toString();
 
-        } catch (IOException | SAXException ex) {
+        } catch (IOException | SAXException | ParserConfigurationException ex) {
             logger.error("Error parsing file {}", fileName, ex);
             throw new BusinessException(ex);
         }

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/rpc/WorkflowServiceImpl.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/rpc/WorkflowServiceImpl.java
@@ -53,7 +53,6 @@ import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.ServletException;
 
-import javax.xml.parsers.ParserConfigurationException;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/rpc/WorkflowServiceImpl.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/rpc/WorkflowServiceImpl.java
@@ -52,6 +52,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.ServletException;
+
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;

--- a/vip-application/src/main/java/localhost/moteur_service_wsdl/Moteur_ServiceLocator.java
+++ b/vip-application/src/main/java/localhost/moteur_service_wsdl/Moteur_ServiceLocator.java
@@ -31,6 +31,8 @@
  */
 package localhost.moteur_service_wsdl;
 
+import java.net.URISyntaxException;
+
 public class Moteur_ServiceLocator extends org.apache.axis.client.Service implements localhost.moteur_service_wsdl.Moteur_Service {
 
     /**
@@ -71,8 +73,10 @@ public class Moteur_ServiceLocator extends org.apache.axis.client.Service implem
     public localhost.moteur_service_wsdl.Moteur_servicePortType getmoteur_service() throws javax.xml.rpc.ServiceException {
         java.net.URL endpoint;
         try {
-            endpoint = new java.net.URL(moteur_service_address);
+            endpoint = new java.net.URI(moteur_service_address).toURL();
         } catch (java.net.MalformedURLException e) {
+            throw new javax.xml.rpc.ServiceException(e);
+        } catch (URISyntaxException e) {
             throw new javax.xml.rpc.ServiceException(e);
         }
         return getmoteur_service(endpoint);
@@ -100,7 +104,7 @@ public class Moteur_ServiceLocator extends org.apache.axis.client.Service implem
     public java.rmi.Remote getPort(Class serviceEndpointInterface) throws javax.xml.rpc.ServiceException {
         try {
             if (localhost.moteur_service_wsdl.Moteur_servicePortType.class.isAssignableFrom(serviceEndpointInterface)) {
-                localhost.moteur_service_wsdl.Moteur_BindingStub _stub = new localhost.moteur_service_wsdl.Moteur_BindingStub(new java.net.URL(moteur_service_address), this);
+                localhost.moteur_service_wsdl.Moteur_BindingStub _stub = new localhost.moteur_service_wsdl.Moteur_BindingStub(new java.net.URI(moteur_service_address).toURL(), this);
                 _stub.setPortName(getmoteur_serviceWSDDServiceName());
                 return _stub;
             }

--- a/vip-application/src/test/java/fr/insalyon/creatis/vip/application/integrationtest/PublicApplicationListIT.java
+++ b/vip-application/src/test/java/fr/insalyon/creatis/vip/application/integrationtest/PublicApplicationListIT.java
@@ -28,15 +28,14 @@ public class PublicApplicationListIT extends BaseSpringIT {
     private ConfigurationBusiness configurationBusiness;
 
     @Test
-    @SuppressWarnings("unchecked")
     public void shouldNotIncludePrivateGroupsAndClasses() throws BusinessException, ApplicationException {
         // prepare test data
         Group publicGroup = new Group("public group", true, true, true);
         Group privateGroup = new Group("private group", false, true, true);
         // classes are not really public/private, but they are linked to public/private groups
         // a class is considered private if it is linked only to private groups
-        AppClass publicClass = new AppClass("public class", Collections.EMPTY_LIST, Collections.singletonList(publicGroup.getName()));
-        AppClass privateClass = new AppClass("private class", Collections.EMPTY_LIST, Collections.singletonList(privateGroup.getName()));
+        AppClass publicClass = new AppClass("public class", Collections.emptyList(), Collections.singletonList(publicGroup.getName()));
+        AppClass privateClass = new AppClass("private class", Collections.emptyList(), Collections.singletonList(privateGroup.getName()));
         Application app = new Application("testApp", Arrays.asList(publicClass.getName(), privateClass.getName()), "");
         AppVersion appVersion = new AppVersion(app.getName(), "", null, null, true, false);
         // persist data in database

--- a/vip-application/src/test/java/fr/insalyon/creatis/vip/application/integrationtest/PublicApplicationListIT.java
+++ b/vip-application/src/test/java/fr/insalyon/creatis/vip/application/integrationtest/PublicApplicationListIT.java
@@ -28,6 +28,7 @@ public class PublicApplicationListIT extends BaseSpringIT {
     private ConfigurationBusiness configurationBusiness;
 
     @Test
+    @SuppressWarnings("unchecked")
     public void shouldNotIncludePrivateGroupsAndClasses() throws BusinessException, ApplicationException {
         // prepare test data
         Group publicGroup = new Group("public group", true, true, true);

--- a/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/auth/SamlAuthenticationService.java
+++ b/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/auth/SamlAuthenticationService.java
@@ -37,6 +37,7 @@ import fr.insalyon.creatis.vip.core.server.business.Server;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
@@ -139,7 +140,7 @@ public class SamlAuthenticationService extends AbstractAuthenticationService {
                 logger.error("Error with SAML assertion {} : audience is not valid", new String(xmlAssertion));
                 throw new BusinessException("Assertion audience is not valid!");
             }
-        } catch (MalformedURLException ex) {
+        } catch (MalformedURLException | URISyntaxException ex) {
             logger.error("Error with SAML assertion {}", new String(xmlAssertion), ex);
             throw new BusinessException(ex);
         }

--- a/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/SamlTokenValidator.java
+++ b/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/SamlTokenValidator.java
@@ -39,7 +39,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URISyntaxException;
+import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.security.KeyFactory;
@@ -174,7 +175,7 @@ public class SamlTokenValidator {
         return true;
     }
 
-    public static boolean isAudienceValid(String server, Assertion assertion) throws MalformedURLException {
+    public static boolean isAudienceValid(String server, Assertion assertion) throws MalformedURLException, URISyntaxException {
         String serverHost = getHost(server);
         if (assertion.getConditions() == null) {
             return true;
@@ -194,7 +195,7 @@ public class SamlTokenValidator {
     }
 
    /// Private methods
-    private static String getHost(String serverURL) throws MalformedURLException {
-        return new URL(serverURL).getHost();
+    private static String getHost(String serverURL) throws MalformedURLException, URISyntaxException {
+        return new URI(serverURL).toURL().getHost();
     }
 }

--- a/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/proxy/ProxyClient.java
+++ b/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/proxy/ProxyClient.java
@@ -152,12 +152,20 @@ public class ProxyClient {
         // Voms Extension
         Server serverConf = server;
         long hours = Long.parseLong(serverConf.getMyProxyLifeTime()) / 3600;
-        String command = "voms-proxy-init -voms " + vo
-                + " -cert " + serverConf.getServerProxy()
-                + " -key " + serverConf.getServerProxy()
-                + " -out " + serverConf.getServerProxy(vo)
-                + " -noregen -valid " + hours + ":00";
-        Process process = Runtime.getRuntime().exec(command);
+        List<String> command = new ArrayList<>();
+        command.add("voms-proxy-init");
+        command.add("-voms");
+        command.add(vo);
+        command.add("-cert");
+        command.add(serverConf.getServerProxy());
+        command.add("-key");
+        command.add(serverConf.getServerProxy());
+        command.add("-out");
+        command.add(serverConf.getServerProxy(vo));
+        command.add("-noregen");
+        command.add("-valid");
+        command.add(hours + ":00");
+        Process process = Runtime.getRuntime().exec(command.toArray(new String[]{}));
 
         BufferedReader r = new BufferedReader(new InputStreamReader(process.getInputStream()));
         String s = null;
@@ -301,7 +309,7 @@ public class ProxyClient {
         outFile.delete();
         outFile.createNewFile();
         // set permission
-        String command = "chmod 0600 " + proxyName;
+        String[] command = new String[]{"chmod", "0600", proxyName};
         Runtime.getRuntime().exec(command);
 
         printStream = new PrintStream(new FileOutputStream(outFile));

--- a/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/rpc/ConfigurationServiceImpl.java
+++ b/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/rpc/ConfigurationServiceImpl.java
@@ -50,6 +50,8 @@ import org.slf4j.LoggerFactory;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -522,24 +524,24 @@ public class ConfigurationServiceImpl extends AbstractRemoteServiceServlet imple
         URL url;
         try {
             url = getBaseURL();
-        } catch (MalformedURLException e) {
+        } catch (MalformedURLException | URISyntaxException e) {
             throw new CoreException(e);
         }
         return configurationBusiness.getLoginUrlCas(url);
     }
 
-    private URL getBaseURL() throws MalformedURLException {
+    private URL getBaseURL() throws MalformedURLException, URISyntaxException {
         URL url;
         HttpServletRequest request = this.getThreadLocalRequest();
         if ((request.getServerPort() == 80)
                 || (request.getServerPort() == 443)) {
-            url = new URL(request.getScheme() + "://"
+            url = new URI(request.getScheme() + "://"
                     + request.getServerName()
-                    + request.getContextPath());
+                    + request.getContextPath()).toURL();
         } else {
-            url = new URL(request.getScheme() + "://"
+            url = new URI(request.getScheme() + "://"
                     + request.getServerName() + ":" + request.getServerPort()
-                    + request.getContextPath());
+                    + request.getContextPath()).toURL();
         }
         return url;
     }

--- a/vip-core/src/test/java/fr/insalyon/creatis/vip/core/integrationtest/database/SpringDatabaseIT.java
+++ b/vip-core/src/test/java/fr/insalyon/creatis/vip/core/integrationtest/database/SpringDatabaseIT.java
@@ -16,6 +16,8 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -148,10 +150,10 @@ public class SpringDatabaseIT extends BaseSpringIT{
     @Test
     @Order(7)
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    public void connectionShouldBeLazyInTransaction() throws SQLException, MalformedURLException {
+    public void connectionShouldBeLazyInTransaction() throws SQLException, MalformedURLException, URISyntaxException {
         // getConnection throw an exception but should not be called as 'getLoginUrlCas' do not need db access
         Mockito.doThrow(SQLException.class).when(dataSource).getConnection();
-        String res = configurationBusiness.getLoginUrlCas(new URL("file:/plop"));
+        String res = configurationBusiness.getLoginUrlCas(new URI("file:/plop").toURL());
         assertEquals(ServerMockConfig.TEST_CAS_URL + "/login?service=file:/plop", res);
         Mockito.reset(dataSource);
     }

--- a/vip-core/src/test/java/fr/insalyon/creatis/vip/core/integrationtest/database/SpringJndiIT.java
+++ b/vip-core/src/test/java/fr/insalyon/creatis/vip/core/integrationtest/database/SpringJndiIT.java
@@ -32,6 +32,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import javax.sql.DataSource;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -217,12 +219,12 @@ public class SpringJndiIT {
 
     @Test
     @Order(8)
-    public void connectionShouldBeLazyInTransaction() throws SQLException, MalformedURLException {
+    public void connectionShouldBeLazyInTransaction() throws SQLException, MalformedURLException, URISyntaxException {
         JdbcTemplate jdbcTemplate = new JdbcTemplate(lazyDataSource);
         // close the datasource to make the next request fail
         try { jdbcTemplate.execute("SHUTDOWN"); } catch (Exception e) {e.printStackTrace();}
         // getConnection throw an exception but should not be called as 'getLoginUrlCas' do not need db access
-        String res = configurationBusiness.getLoginUrlCas(new URL("file:/plop"));
+        String res = configurationBusiness.getLoginUrlCas(new URI("file:/plop").toURL());
         assertEquals(ServerMockConfig.TEST_CAS_URL + "/login?service=file:/plop", res);
     }
 }

--- a/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/GirderStorageBusiness.java
+++ b/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/GirderStorageBusiness.java
@@ -51,6 +51,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.sql.Connection;
 import java.util.Optional;
@@ -154,7 +156,7 @@ public class GirderStorageBusiness {
             ObjectNode node =
                 new ObjectMapper().readValue(res.response, ObjectNode.class);
             return node.get("authToken").get("token").asText();
-        } catch (IOException | NullPointerException ex) {
+        } catch (IOException | NullPointerException | URISyntaxException ex) {
             logger.error("Error getting girder token for {} with key {}",
                     userEmail, key, ex);
             throw new BusinessException("Unable to get token from api key", ex);
@@ -183,7 +185,7 @@ public class GirderStorageBusiness {
 
             // clean filename as in an uploaded file
             return DataManagerUtil.getCleanFilename(name);
-        } catch (IOException ex) {
+        } catch (IOException | URISyntaxException ex) {
             logger.error("Error getting girder filename for {} with token {}",
                     fileId, token, ex);
             throw new BusinessException("Unable to get file info", ex);
@@ -196,9 +198,9 @@ public class GirderStorageBusiness {
         String surl,
         String method,
         Optional<Consumer<HttpURLConnection>> connectionUpdater)
-        throws IOException {
+        throws IOException, URISyntaxException {
 
-        URL url = new URL(surl);
+        URL url = new URI(surl).toURL();
 
         HttpURLConnection con = (HttpURLConnection) url.openConnection();
         con.setRequestMethod(method);

--- a/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/rpc/FileUploadServiceImpl.java
+++ b/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/rpc/FileUploadServiceImpl.java
@@ -41,9 +41,9 @@ import fr.insalyon.creatis.vip.datamanager.client.view.DataManagerException;
 import fr.insalyon.creatis.vip.datamanager.server.DataManagerUtil;
 import fr.insalyon.creatis.vip.datamanager.server.business.DataManagerBusiness;
 import fr.insalyon.creatis.vip.datamanager.server.business.LfcPathsBusiness;
-import org.apache.commons.fileupload2.core.FileItem;
-import org.apache.commons.fileupload2.core.FileItemFactory;
+import org.apache.commons.fileupload2.core.DiskFileItem;
 import org.apache.commons.fileupload2.core.DiskFileItemFactory;
+import org.apache.commons.fileupload2.jakarta.servlet6.JakartaServletDiskFileUpload;
 import org.apache.commons.fileupload2.jakarta.servlet6.JakartaServletFileUpload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,7 +57,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.PrintWriter;
 import java.text.Normalizer;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -85,7 +84,6 @@ public class FileUploadServiceImpl extends HttpServlet {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     protected void doPost(HttpServletRequest request, HttpServletResponse response)
             throws ServletException {
 
@@ -94,12 +92,11 @@ public class FileUploadServiceImpl extends HttpServlet {
             logger.info("upload received from " + user.getEmail());
             if (user != null && JakartaServletFileUpload.isMultipartContent(request)) {
 
-                FileItemFactory factory = DiskFileItemFactory.builder().get();
-                JakartaServletFileUpload upload = new JakartaServletFileUpload(factory);
-                List items = upload.parseRequest(request);
-                Iterator iter = items.iterator();
+                DiskFileItemFactory factory = DiskFileItemFactory.builder().get();
+                JakartaServletDiskFileUpload upload = new JakartaServletDiskFileUpload(factory);
+                List<DiskFileItem> items = upload.parseRequest(request);
                 String fileName = null;
-                FileItem fileItem = null;
+                DiskFileItem fileItem = null;
                 String path = null;
                 String target = "uploadComplete";
                 boolean single = true;
@@ -107,9 +104,7 @@ public class FileUploadServiceImpl extends HttpServlet {
                 boolean usePool = true;
                 String operationID = "no-id";
 
-                while (iter.hasNext()) {
-                    FileItem item = (FileItem) iter.next();
-
+                for (DiskFileItem item : items) {
                     switch (item.getFieldName()) {
                         case "path":
                             path = item.getString();

--- a/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/rpc/FileUploadServiceImpl.java
+++ b/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/rpc/FileUploadServiceImpl.java
@@ -85,6 +85,7 @@ public class FileUploadServiceImpl extends HttpServlet {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     protected void doPost(HttpServletRequest request, HttpServletResponse response)
             throws ServletException {
 

--- a/vip-gatelab/src/main/java/fr/insalyon/creatis/vip/gatelab/server/business/GateLabInputsParser.java
+++ b/vip-gatelab/src/main/java/fr/insalyon/creatis/vip/gatelab/server/business/GateLabInputsParser.java
@@ -33,6 +33,7 @@ package fr.insalyon.creatis.vip.gatelab.server.business;
 
 import java.io.FileReader;
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -46,6 +47,9 @@ import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 import org.xml.sax.helpers.XMLReaderFactory;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
 
 /**
  * Parse a gatelab input file.
@@ -72,13 +76,15 @@ public class GateLabInputsParser extends DefaultHandler {
 
     public Map<String, String> parse(String fileName) {
         try {
-            reader = XMLReaderFactory.createXMLReader();
+            SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+            parserFactory.setNamespaceAware(true);
+            reader = parserFactory.newSAXParser().getXMLReader();
             reader.setContentHandler(this);
             reader.parse(new InputSource(new FileReader(fileName)));
 
             return inputsMap;
 
-        } catch (IOException | SAXException ex) {
+        } catch (IOException | SAXException | ParserConfigurationException ex) {
             logger.error("Error parsing {}", fileName, ex);
         }
         return null;

--- a/vip-portal/src/test/java/fr/insalyon/creatis/applicationimporter/GwendiaTemplateTest.java
+++ b/vip-portal/src/test/java/fr/insalyon/creatis/applicationimporter/GwendiaTemplateTest.java
@@ -27,7 +27,7 @@ public class GwendiaTemplateTest {
 
     @ParameterizedTest
     @ValueSource(strings = {STANDALONE_TEMPLATE})
-    public void testTemplateWithNonNullDescription(String template) throws IOException, InvalidBoutiquesDescriptorException, SAXException {
+    public void testTemplateWithNonNullDescription(String template) throws IOException, InvalidBoutiquesDescriptorException, SAXException, ParserConfigurationException {
         String inputDescription = "test input description";
         Descriptor gwendiaDesc = testGwendiaTemplate(
                 template,
@@ -38,7 +38,7 @@ public class GwendiaTemplateTest {
 
     @ParameterizedTest
     @ValueSource(strings = {STANDALONE_TEMPLATE})
-    public void testTemplateWithNullDescription(String template) throws IOException, InvalidBoutiquesDescriptorException, SAXException {
+    public void testTemplateWithNullDescription(String template) throws IOException, InvalidBoutiquesDescriptorException, SAXException, ParserConfigurationException {
         // when the description is not in boutiques, it must be an empty string in gwendia
         Descriptor gwendiaDesc = testGwendiaTemplate(
                 template,
@@ -49,7 +49,7 @@ public class GwendiaTemplateTest {
 
     @ParameterizedTest
     @ValueSource(strings = {STANDALONE_TEMPLATE})
-    public void testTemplateWithAIntegerInput(String template) throws IOException, InvalidBoutiquesDescriptorException, SAXException {
+    public void testTemplateWithAIntegerInput(String template) throws IOException, InvalidBoutiquesDescriptorException, SAXException, ParserConfigurationException {
         Descriptor gwendiaDesc = testGwendiaTemplate(
                 template,
                 getIntegerInput(1, 42.));
@@ -58,7 +58,7 @@ public class GwendiaTemplateTest {
 
     @ParameterizedTest
     @ValueSource(strings = {STANDALONE_TEMPLATE})
-    public void testTemplateWithANumberInput(String template) throws IOException, InvalidBoutiquesDescriptorException, SAXException {
+    public void testTemplateWithANumberInput(String template) throws IOException, InvalidBoutiquesDescriptorException, SAXException, ParserConfigurationException {
         Descriptor gwendiaDesc = testGwendiaTemplate(
                 template,
                 getNumberInput(1, false, 42.));
@@ -80,18 +80,14 @@ public class GwendiaTemplateTest {
                 true, null, null, null, null, null, defaultValue);
     }
 
-    protected Descriptor testGwendiaTemplate(String templateFile, BoutiquesInput... inputs) throws IOException, SAXException  {
+    protected Descriptor testGwendiaTemplate(String templateFile, BoutiquesInput... inputs) throws IOException, SAXException, ParserConfigurationException  {
         BoutiquesApplication boutiquesApp = new BoutiquesApplication("testApp", "test app desc", "42.43");
         for (BoutiquesInput input : inputs) {
             boutiquesApp.addInput(input);
         }
         VelocityUtils sut = new VelocityUtils();
         String gwendiaString = sut.createDocument(boutiquesApp, "lnf:", templateFile);
-        try {
-            return new GwendiaParser().parseString(gwendiaString);
-        } catch(ParserConfigurationException e) {
-            throw new SAXException(e);
-        }
+        return new GwendiaParser().parseString(gwendiaString);
     }
 
 }

--- a/vip-portal/src/test/java/fr/insalyon/creatis/applicationimporter/GwendiaTemplateTest.java
+++ b/vip-portal/src/test/java/fr/insalyon/creatis/applicationimporter/GwendiaTemplateTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.xml.sax.SAXException;
 
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 
 /*
@@ -79,14 +80,18 @@ public class GwendiaTemplateTest {
                 true, null, null, null, null, null, defaultValue);
     }
 
-    protected Descriptor testGwendiaTemplate(String templateFile, BoutiquesInput... inputs) throws IOException, SAXException {
+    protected Descriptor testGwendiaTemplate(String templateFile, BoutiquesInput... inputs) throws IOException, SAXException  {
         BoutiquesApplication boutiquesApp = new BoutiquesApplication("testApp", "test app desc", "42.43");
         for (BoutiquesInput input : inputs) {
             boutiquesApp.addInput(input);
         }
         VelocityUtils sut = new VelocityUtils();
         String gwendiaString = sut.createDocument(boutiquesApp, "lnf:", templateFile);
-        return new GwendiaParser().parseString(gwendiaString);
+        try {
+            return new GwendiaParser().parseString(gwendiaString);
+        } catch(ParserConfigurationException e) {
+            throw new SAXException(e);
+        }
     }
 
 }


### PR DESCRIPTION
This patch fixes all build warnings under Intellij+Maven with java21. No functional change.

- Remove deprecated PathMatchConfigurer. setUseSuffixPatternMatch(false) is now the default in Spring, cf https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/config/annotation/PathMatchConfigurer.html#isUseSuffixPatternMatch()).
- Replace deprecated ReaderInputStream with ReaderInputStream.builder()
- Replace deprecated XMLReaderFactory with SAXParserFactory
- Replace deprecated Integer(string) with Integer.parseInt(string)
- Replace deprecated URL() constructor with URI().toURL()
- Replace deprecated string-based Runtime.getRuntime().exec() with its array-based variant
- Add @SuppressWarnings("unchecked") in all places with an "unchecked" warning. This is not ideal but we lack of a better alternative.