### PR TITLE
Add --stream flag to bosh exec launch

### DIFF
--- a/vip-portal/src/main/resources/vm/wrapper.vm
+++ b/vip-portal/src/main/resources/vm/wrapper.vm
@@ -200,9 +200,9 @@ mkdir -p $TMP_FOLDER
 #set($jsonFile="${tool.getName()}.json")
 
 #if($imagepath)
-PYTHONPATH=".:$PYTHONPATH" $BOSHEXEC exec launch --imagepath $imagepath $jsonFile input_param_file.json -v $PWD/../cache:$PWD/../cache -v $TMP_FOLDER:/tmp
+PYTHONPATH=".:$PYTHONPATH" $BOSHEXEC exec launch --stream --imagepath $imagepath $jsonFile input_param_file.json -v $PWD/../cache:$PWD/../cache -v $TMP_FOLDER:/tmp
 #else
-PYTHONPATH=".:$PYTHONPATH" $BOSHEXEC exec launch $jsonFile input_param_file.json -v $PWD/../cache:$PWD/../cache -v $TMP_FOLDER:/tmp
+PYTHONPATH=".:$PYTHONPATH" $BOSHEXEC exec launch --stream $jsonFile input_param_file.json -v $PWD/../cache:$PWD/../cache -v $TMP_FOLDER:/tmp
 #end
 
 if [ $? != 0 ]

--- a/vip-portal/src/test/java/fr/insalyon/creatis/applicationimporter/WrapperTemplateTest.java
+++ b/vip-portal/src/test/java/fr/insalyon/creatis/applicationimporter/WrapperTemplateTest.java
@@ -35,11 +35,11 @@ public class WrapperTemplateTest {
         VelocityUtils sut = new VelocityUtils();
         // if null
         String wrapperString = sut.createDocument(null, boutiquesApp, false, WRAPPER_TEMPLATE);
-        MatcherAssert.assertThat(wrapperString, containsString("exec launch testApp.json input_param_file.json"));
+        MatcherAssert.assertThat(wrapperString, containsString("exec launch --stream testApp.json input_param_file.json"));
         // if present
         boutiquesApp.setVipContainer("testContainer");
         wrapperString = sut.createDocument(null, boutiquesApp, false, WRAPPER_TEMPLATE);
-        MatcherAssert.assertThat(wrapperString, containsString("exec launch --imagepath testContainer testApp.json input_param_file.json"));
+        MatcherAssert.assertThat(wrapperString, containsString("exec launch --stream --imagepath testContainer testApp.json input_param_file.json"));
     }
 
 }


### PR DESCRIPTION
This patch adds the `--stream` flag to bosh exec launch.
From http://boutiques.github.io/doc/_execute.html : "Streams stdout and stderr in real time during execution."

As the change is in wrapper.vm, under Moteur2, it will only be effective when an app script is regenerated, for instance on app import.

In practice, this change allows the "Peek StandardOutput" action on Dirac to view the app output during execution, and changes the visible output in VIP-portal UI "View Application Output" as follows :
- Before the patch :
```
Shell command
echo stdout && echo stderr && out >./output.txt
Container location

Container command

Exit code
0
Std out
stdout

Std out
stderr

Error message

Output files
- output.txt (output1, Required)
```

- After the patch :
```
stdout
stderr
Shell command
echo stdout && echo stderr && out >./output.txt
Container location

Container command

Exit code
0
Error message

Output files
- output.txt (output1, Required)
```
