### PR TITLE
Fix icons size in Executions UI, and a warning

### DIFF
--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/monitor/general/LogsLayout.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/monitor/general/LogsLayout.java
@@ -74,6 +74,8 @@ public class LogsLayout extends AbstractFormLayout {
 
         DetailViewerField pictureField = new DetailViewerField("picture");
         pictureField.setType("image");
+        pictureField.setImageHeight(48);
+        pictureField.setImageWidth(48);
         DetailViewerField commonNameField = new DetailViewerField("commonName");
 
         tileGrid.setFields(pictureField, commonNameField);

--- a/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/EmailBusiness.java
+++ b/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/EmailBusiness.java
@@ -28,7 +28,7 @@ public class EmailBusiness {
         } else {
             logger.info("SMA disabled, not sending email and logging it");
             logger.info("subject : {}", subject);
-            logger.info("recipients : {}", recipients);
+            logger.info("recipients : {}", (Object[])recipients);
             logger.info("content : {}", content);
         }
     }


### PR DESCRIPTION
Very minor patch which :
- Fixes incorrect icon size in the `image` tag of Executions logs UI. These icons look bad since the Java21/GWT upgrade, and the fix is identical to what was already done in #503 for the Home page. I also checked that there are no other usages of such tags in VIP-portal.
- Fixes a recently introduced warning in EmailBusiness.java ("non-varargs call of varargs method with inexact argument type for last parameter")
