### PR TITLE
Data API fixes, using Grida getPathInfo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
 
         <!-- VIP related dependencies version -->
         <moteur2-workflowsdb-common.version>1.8.0-SNAPSHOT</moteur2-workflowsdb-common.version>
-        <grida.version>2.2.0</grida.version>
+        <grida.version>2.3.0-SNAPSHOT</grida.version>
         <sma.version>0.3.0</sma.version>
 
         <!-- 3rd party dependencies version -->

--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/DataApiBusiness.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/DataApiBusiness.java
@@ -180,7 +180,12 @@ public class DataApiBusiness {
         if (path.equals(ROOT)) {
             return getRootSubDirectoriesPathProps();
         }
-        if (!baseIsDirectory(path)) {
+        Optional<Data.Type> type = baseGetPathInfo(path);
+        if (!type.isPresent()) { // path doesn't exist
+            logger.error("Trying to list a non-existing path ({})", path);
+            throw new ApiException("Error listing a directory");
+        }
+        if (!type.get().equals(Data.Type.folder)) {
             logger.error("Trying to list {} , but is a file :", path);
             throw new ApiException("Error listing a directory");
         }
@@ -525,11 +530,6 @@ public class DataApiBusiness {
         } catch (BusinessException e) {
             throw new ApiException("Error testing file existence", e);
         }
-    }
-
-    private boolean baseIsDirectory(String path) throws ApiException {
-        Optional<Data.Type> type = baseGetPathInfo(path);
-        return type.isPresent() && type.get().equals(Data.Type.folder);
     }
 
     private Optional<Data.Type> baseGetPathInfo(String path) throws ApiException {

--- a/vip-api/src/test/java/fr/insalyon/creatis/vip/api/rest/itest/processing/ExecutionControllerIT.java
+++ b/vip-api/src/test/java/fr/insalyon/creatis/vip/api/rest/itest/processing/ExecutionControllerIT.java
@@ -32,6 +32,7 @@
 package fr.insalyon.creatis.vip.api.rest.itest.processing;
 
 import fr.insalyon.creatis.grida.common.bean.GridData;
+import fr.insalyon.creatis.grida.common.bean.GridPathInfo;
 import fr.insalyon.creatis.moteur.plugins.workflowsdb.bean.*;
 import fr.insalyon.creatis.moteur.plugins.workflowsdb.dao.WorkflowsDBDAOException;
 import fr.insalyon.creatis.vip.api.exception.ApiException;
@@ -326,7 +327,7 @@ public class ExecutionControllerIT extends BaseWebSpringIT {
         when(outputDAO.get(eq(simulation2.getID()))).thenReturn(Arrays.asList(output), (List<Output>) null);
 
         Mockito.when(server.getDataManagerUsersHome()).thenReturn("/root/user");
-        Mockito.when(gridaClient.exist(resultPath)).thenReturn(true);
+        Mockito.when(gridaClient.getPathInfo(resultPath)).thenReturn(new GridPathInfo(true, GridData.Type.File));
         Mockito.when(gridaClient.getFolderData(resultPath, true)).thenReturn(Arrays.asList(
                 new GridData("result.res", GridData.Type.File, 42, "modifData", "", "", "")));
 

--- a/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/LFCBusiness.java
+++ b/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/LFCBusiness.java
@@ -45,7 +45,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/LFCBusiness.java
+++ b/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/LFCBusiness.java
@@ -34,6 +34,7 @@ package fr.insalyon.creatis.vip.datamanager.server.business;
 import fr.insalyon.creatis.grida.client.GRIDAClient;
 import fr.insalyon.creatis.grida.client.GRIDAClientException;
 import fr.insalyon.creatis.grida.common.bean.GridData;
+import fr.insalyon.creatis.grida.common.bean.GridPathInfo;
 import fr.insalyon.creatis.vip.core.client.bean.User;
 import fr.insalyon.creatis.vip.core.server.business.BusinessException;
 import fr.insalyon.creatis.vip.datamanager.client.bean.Data;
@@ -43,6 +44,8 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -159,10 +162,15 @@ public class LFCBusiness {
         }
     }
 
-    public Data.Type getPathInfo(User user, String path) throws BusinessException {
+    public Optional<Data.Type> getPathInfo(User user, String path) throws BusinessException {
         try {
-            GridData.Type type = gridaClient.getPathInfo(lfcPathsBusiness.parseBaseDir(user, path));
-            return Data.Type.valueOf(type.name().toLowerCase());
+            // convert GridPathInfo to an Optional<Data.Type> to avoid a new structure in vip.datamanager
+            GridPathInfo pathInfo = gridaClient.getPathInfo(lfcPathsBusiness.parseBaseDir(user, path));
+            if (pathInfo.exist()) {
+                return Optional.of(Data.Type.valueOf(pathInfo.getType().name().toLowerCase()));
+            } else {
+                return Optional.empty();
+            }
         } catch (GRIDAClientException ex) {
             logger.error("Error getting path info {} for {}", path, user, ex);
             throw new BusinessException(ex);

--- a/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/LFCBusiness.java
+++ b/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/LFCBusiness.java
@@ -159,6 +159,18 @@ public class LFCBusiness {
         }
     }
 
+    public Data.Type getPathInfo(User user, String path) throws BusinessException {
+        try {
+            GridData.Type type = gridaClient.getPathInfo(lfcPathsBusiness.parseBaseDir(user, path));
+            return Data.Type.valueOf(type.name().toLowerCase());
+        } catch (GRIDAClientException ex) {
+            logger.error("Error getting path info {} for {}", path, user, ex);
+            throw new BusinessException(ex);
+        } catch (DataManagerException ex) {
+            throw new BusinessException(ex);
+        }
+    }
+
     public long getModificationDate(User user, String path) throws BusinessException {
 
         try {

--- a/vip-local/src/main/java/fr/insalyon/creatis/vip/local/GridaClientLocal.java
+++ b/vip-local/src/main/java/fr/insalyon/creatis/vip/local/GridaClientLocal.java
@@ -161,16 +161,6 @@ public class GridaClientLocal extends GRIDAClient {
     }
 
     @Override
-    public String uploadFileToSE(String localFile, String remoteDir, String storageElement) throws GRIDAClientException {
-        throw new GRIDAClientException("not implemented in local version");
-    }
-
-    @Override
-    public String uploadFileToSE(String localFile, String remoteDir, List<String> storageElementsList) throws GRIDAClientException {
-        throw new GRIDAClientException("not implemented in local version");
-    }
-
-    @Override
     public void replicateToPreferredSEs(String remoteFile) throws GRIDAClientException {
         throw new GRIDAClientException("not implemented in local version");
     }


### PR DESCRIPTION
This patch uses the new `getPathInfo()` Grida command (https://github.com/virtual-imaging-platform/GRIDA/pull/44) to fix some existing bugs in VIP Data API regarding file/directory testing. In practice, visible changes for a VIP-API client are as follows :

On `GET /rest/path?action=list` :
- the API call was failing on a directory that contained a single item named as its parent. It now works.
- the API call was reporting `HTTP 200` with a body of `[]` when listing a non-existing path. It now correctly fails with `HTTP 400`.
- these fixes come at the cost of an extra `COM_GET_PATH_INFO` before the existing `COM_LIST_FILES_AND_FOLDERS`

On `GET /rest/path?action=properties` :
- the `isDirectory` property was incorrectly `false` on a directory that contained a single item named as its parent. It is now `true`.
- all other situations should be unchanged, and the number of Grida calls is the same as before, since `COM_EXIST` was replaced with  `COM_GET_PATH_INFO`