### PR TITLE
fix relative and absolute "file:" paths

### DIFF
--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowBusiness.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowBusiness.java
@@ -299,9 +299,8 @@ public class WorkflowBusiness {
             return parseResult.result;
         }
         // not an external platform parameter, use legacy format
-        String parsedPath = lfcPathsBusiness.parseBaseDir(
-                user, parameterValue);
-        if (!user.isSystemAdministrator()) {
+        String parsedPath = lfcPathsBusiness.parseBaseDir(user, parameterValue);
+        if ( ! user.isSystemAdministrator()) {
             checkFolderACL(user, groups, parsedPath);
         }
         if ( ! parsedPath.equals(parameterValue) // the parameter is a file path

--- a/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/LfcPathsBusiness.java
+++ b/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/LfcPathsBusiness.java
@@ -99,6 +99,8 @@ public class LfcPathsBusiness {
 
         if (baseDir.startsWith("lfn://")) {
             baseDir = URI.create(baseDir).getPath();
+        } else if (baseDir.startsWith("file:")) {
+            baseDir = baseDir.substring(5,  baseDir.length());
         }
 
         baseDir = replaceLfnUserPrefix(
@@ -123,14 +125,15 @@ public class LfcPathsBusiness {
     }
 
     private String replaceLfnUserPrefix(String path, String currentUserFolder, String... prefixesToReplace) {
+
         String prefixToReplace = null;
         for (String prefixToTest : prefixesToReplace) {
-            if (prefixToTest != null && !prefixToTest.isEmpty()
-                    && path.contains(prefixToTest)) {
+            if (prefixToTest != null && !prefixToTest.isEmpty() && path.contains(prefixToTest)) {
                 prefixToReplace = prefixToTest;
                 break;
             }
         }
+
         if (prefixToReplace != null) {
             path = path.replace(prefixToReplace + "/", "");
 

--- a/vip-datamanagement/src/test/java/fr/insalyon/creatis/vip/datamanager/server/business/LfcPathsBusinessTest.java
+++ b/vip-datamanagement/src/test/java/fr/insalyon/creatis/vip/datamanager/server/business/LfcPathsBusinessTest.java
@@ -1,0 +1,59 @@
+package fr.insalyon.creatis.vip.datamanager.server.business;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import fr.insalyon.creatis.vip.core.client.bean.User;
+import fr.insalyon.creatis.vip.core.server.business.Server;
+import fr.insalyon.creatis.vip.core.server.dao.DAOException;
+import fr.insalyon.creatis.vip.core.server.dao.GroupDAO;
+import fr.insalyon.creatis.vip.datamanager.client.view.DataManagerException;
+
+public class LfcPathsBusinessTest {
+
+    @Mock
+    private Server server;
+
+    @Mock
+    private GroupDAO groupDAO;
+
+    @Mock
+    private User user;
+
+    private LfcPathsBusiness lfcPathsBusiness;
+
+    @BeforeEach
+    public void init() throws DAOException {
+        MockitoAnnotations.openMocks(this);
+
+        when(server.getVoRoot()).thenReturn("/var/data");
+        when(server.getDataManagerUsersHome()).thenReturn("/var/data/users");
+        when(server.getDataManagerGroupsHome()).thenReturn("/var/data/groups");
+        when(server.getAltDataManagerUsersHome()).thenReturn("");
+        when(server.getAltDataManagerGroupsHome()).thenReturn("");
+
+        when(groupDAO.getGroups()).thenReturn(Collections.emptyList());
+        when(user.getFolder()).thenReturn("test_user");
+
+        lfcPathsBusiness = new LfcPathsBusiness(server, groupDAO);
+    }
+
+    @Test
+    public void localFileTransformations() throws DataManagerException {
+        String relativePath = "/vip/Home/my_file.txt";
+        String absolutePath = "/var/data/users/test_user/my_file.txt";
+
+        assertEquals(absolutePath, 
+            lfcPathsBusiness.parseBaseDir(user, relativePath));
+
+        assertEquals(relativePath, 
+            lfcPathsBusiness.parseRealDir(absolutePath, user.getFolder()));
+    }
+}


### PR DESCRIPTION
An issue occurred since we were adding "file:" to every local paths and it was breaking the realpath <-> basepath conversion.
The issue is fixed + units tests related.