### PR TITLE
Move timestamp auto-append to Moteurlite

### DIFF
--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/rpc/WorkflowServiceImpl.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/rpc/WorkflowServiceImpl.java
@@ -231,7 +231,6 @@ public class WorkflowServiceImpl extends AbstractRemoteServiceServlet implements
             for (Map.Entry<String,String> p : parametersMap.entrySet()) {
                 logger.info("received param {} : {}", p.getKey(), p.getValue());
             }
-            addTimestampedSubDirectoryIfNecessary(parametersMap);
 
             String simulationID = workflowBusiness.launch(
                 user, groups,
@@ -242,24 +241,6 @@ public class WorkflowServiceImpl extends AbstractRemoteServiceServlet implements
 
         } catch (BusinessException | CoreException ex) {
             throw new ApplicationException(ex);
-        }
-    }
-
-    private void addTimestampedSubDirectoryIfNecessary(Map<String, String> parametersMap) {
-        if (server.useMoteurlite()) {
-            if (parametersMap.containsKey(CoreConstants.RESULTS_DIRECTORY_PARAM_NAME)) {
-                String resultDir = parametersMap.get(CoreConstants.RESULTS_DIRECTORY_PARAM_NAME);
-                if (resultDir.startsWith("/") || resultDir.startsWith("lfn:")) {
-                    DateFormat dateFormat = new SimpleDateFormat("dd-MM-yyyy_HHmmss");
-                    resultDir = resultDir + "/" + (dateFormat.format(System.currentTimeMillis()));
-                    parametersMap.put(CoreConstants.RESULTS_DIRECTORY_PARAM_NAME, resultDir);
-                    logger.info("For MoteurLite : changing results-directory to : {}", resultDir);
-                } else {
-                    logger.info("Using MoteurLite but results-directory not a LFN ({})", resultDir);
-                }
-            } else {
-                logger.info("Using MoteurLite but no results-directory given -> no subdirectory added");
-            }
         }
     }
 


### PR DESCRIPTION
This patch goes along with the addition of the `"vip:outDir"` custom property in https://github.com/virtual-imaging-platform/vip-workflow-engine/pull/9 :
- In VIP-portal, it removes the automatic addition of a `dd-MM-yyyy_HHmmss` timestamp subdir to `results-directory`, which was done for Moteurlite executions launched from the UI, but not from the API.
- By default, the equivalent feature in Moteurlite still adds a timestamp subdir to `results-directory`, with two changes :
  - The subdir name changes to `yyyy-MM-dd_HHmmss` for easier sorting.
  - The subdir is added for any execution, whether it's launched from UI or API.
 