### PR TITLE
Fix mapping of Keycloak roles

### DIFF
--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/security/ApiSecurityConfig.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/security/ApiSecurityConfig.java
@@ -54,8 +54,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
-import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
@@ -184,16 +182,5 @@ public class ApiSecurityConfig {
         firewall.setAllowUrlEncodedSlash(true);
         return firewall;
     }
-
-    /**
-     * customize roles to match keycloak roles without ROLE_
-     */
-    @Bean
-    public GrantedAuthoritiesMapper grantedAuthoritiesMapper() {
-        SimpleAuthorityMapper mapper = new SimpleAuthorityMapper();
-        mapper.setConvertToUpperCase(true);
-        return mapper;
-    }
-
 
 }

--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/security/oidc/OidcToken.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/security/oidc/OidcToken.java
@@ -5,13 +5,13 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
 import fr.insalyon.creatis.vip.core.client.bean.User;
 
-import java.util.List;
+import java.util.Collection;
 
 public class OidcToken extends AbstractAuthenticationToken {
     private final User user;
     private Jwt jwt;
 
-    public OidcToken(User user, Jwt jwt, List<GrantedAuthority> authorities) {
+    public OidcToken(User user, Jwt jwt, Collection<GrantedAuthority> authorities) {
         super(authorities);
         this.user = user;
         this.jwt = jwt;


### PR DESCRIPTION
This fixes a regression introduced in [#512](https://github.com/virtual-imaging-platform/VIP-portal/pull/512) regarding how Keycloak roles are mapped to SpringSecurity authorities :
- before [#512](https://github.com/virtual-imaging-platform/VIP-portal/pull/512), the mapping was done by a [SimpleAuthorityMapper](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/core/authority/mapping/SimpleAuthorityMapper.html) bean, which had the effect of converting role strings to uppercase, and implicitly adding a `ROLE_` prefix (Spring default prefix as per https://docs.spring.io/spring-security/reference/servlet/authorization/architecture.html).
- in [#512](https://github.com/virtual-imaging-platform/VIP-portal/pull/512), our code was changed to use a custom AuthenticationManager and JWT Converter, causing the mapper bean to no longer being used, and role strings to be kept unchanged when converted into authorities in `OidcResover.parseAuthorities()`.

The impact is that accounts with an `ADMINISTRATOR` or `ADVANCED` role in Keycloak were no longer allowed to access the `/rest/statistics/**` endpoints after [#512](https://github.com/virtual-imaging-platform/VIP-portal/pull/512), and similarly for `SERVICE` role on `/rest/executions/{executionId}/summary`. Adding the `ROLE_` prefix explicitly in Keycloak can be used as a temporary workaround. Also note that Spring SimpleAuthorityMapper only adds the `ROLE_` prefix if it's not already there, so in practice `ROLE_ADMINISTRATOR` in Keycloak works both with the buggy and the fixed versions.
