### PR TITLE
Shanoir URL : support different prefixes and update parsing

### DIFF
--- a/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/ShanoirStorageBusiness.java
+++ b/vip-datamanagement/src/main/java/fr/insalyon/creatis/vip/datamanager/server/business/ShanoirStorageBusiness.java
@@ -20,7 +20,7 @@ public class ShanoirStorageBusiness {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     enum UrlKeys{
-        FILE_NAME("shanoir", "^shanoir:/(//)?([^/].*)\\?.*$", 2 ,"fileName"),
+        FILE_NAME("shanoir", "^[^:]+:/(//)?([^/].*)\\?.*$", 2 ,"fileName"),
         RESOURCE_ID("resourceId", "^.*[?&]resourceId=([^&]*)(&.*)?$", 1 ,"resourceId"),
         FORMAT("format", "^.*[?&]format=([^&]*)(&.*)?$", 1 ,"format"),
         TOKEN("token", "^.*[?&]token=([^&]*)(&.*)?$", 1 , "token"),
@@ -104,7 +104,7 @@ public class ShanoirStorageBusiness {
             logger.error("A shanoir external storage must have an URL to generate an URI");
             throw new BusinessException("Cannot generate shanoir uri");
         }
-        if (externalPlatform.getKeycloakClientId() == null || externalPlatform.getRefreshTokenUrl() == null) { 
+        if (externalPlatform.getUploadUrl() == null || externalPlatform.getRefreshTokenUrl() == null) {
             logger.error("Cannot get keycloak informations for shanoir storage from database");
             throw new BusinessException("Cannot generate shanoir uri");
         }

--- a/vip-datamanagement/src/test/java/fr/insalyon/creatis/vip/datamanager/server/business/ShanoirStorageBusinessTest.java
+++ b/vip-datamanagement/src/test/java/fr/insalyon/creatis/vip/datamanager/server/business/ShanoirStorageBusinessTest.java
@@ -1,0 +1,42 @@
+package fr.insalyon.creatis.vip.datamanager.server.business;
+
+import fr.insalyon.creatis.vip.core.server.business.BusinessException;
+import fr.insalyon.creatis.vip.datamanager.client.bean.ExternalPlatform;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ShanoirStorageBusinessTest {
+
+    @Test
+    public void testShanoirUri() throws BusinessException {
+        ShanoirStorageBusiness shanoirStorageBusiness = new ShanoirStorageBusiness();
+        ExternalPlatform externalPlatform = new ExternalPlatform();
+        externalPlatform.setType(ExternalPlatform.Type.SHANOIR);
+        externalPlatform.setUrl("testShanoirUrl");
+        externalPlatform.setRefreshTokenUrl("testRefreshTokenUrl");
+        externalPlatform.setUploadUrl("testUploadUrl");
+
+        String value = "testShanoir:/path/to/file.txt?" +
+                "resourceId=testResourceId" +
+                "&format=testFormat" +
+                "&token=testToken" +
+                "&refreshToken=testRefreshToken" +
+                "&clientId=testKeycloakClientId" +
+                "&converterId=testConverterId";
+
+        String uri = shanoirStorageBusiness.generateUri(externalPlatform, "paramName", value);
+
+        String expectedUri="shanoir:/path/to/file.txt?" +
+                "apiUrl=testShanoirUrl" +
+                "&amp;resourceId=testResourceId" +
+                "&amp;format=testFormat" +
+                "&amp;converterId=testConverterId" +
+                "&amp;keycloak_client_id=testKeycloakClientId" +
+                "&amp;refresh_token_url=testRefreshTokenUrl" +
+                "&amp;token=testToken" +
+                "&amp;refreshToken=testRefreshToken";
+
+        Assertions.assertEquals(expectedUri, uri);
+
+    }
+}

--- a/vip-datamanagement/src/test/java/fr/insalyon/creatis/vip/datamanager/server/business/ShanoirStorageBusinessTest.java
+++ b/vip-datamanagement/src/test/java/fr/insalyon/creatis/vip/datamanager/server/business/ShanoirStorageBusinessTest.java
@@ -71,4 +71,20 @@ public class ShanoirStorageBusinessTest {
 
         Assertions.assertEquals(expectedUri, uploadUri);
     }
+
+    @Test
+    public void testShanoirInvalidUri() throws BusinessException {
+        ShanoirStorageBusiness shanoirStorageBusiness = new ShanoirStorageBusiness();
+        ExternalPlatform externalPlatform = new ExternalPlatform();
+        externalPlatform.setIdentifier("testShanoir");
+        externalPlatform.setType(ExternalPlatform.Type.SHANOIR);
+        externalPlatform.setUrl("testShanoirUrl");
+        externalPlatform.setRefreshTokenUrl("testRefreshTokenUrl");
+        externalPlatform.setUploadUrl("testUploadUrl");
+
+        String value = " invalid uri://";
+
+        Assertions.assertThrows(BusinessException.class,
+                () -> shanoirStorageBusiness.generateUri(externalPlatform, "paramName", value));
+    }
 }

--- a/vip-datamanagement/src/test/java/fr/insalyon/creatis/vip/datamanager/server/business/ShanoirStorageBusinessTest.java
+++ b/vip-datamanagement/src/test/java/fr/insalyon/creatis/vip/datamanager/server/business/ShanoirStorageBusinessTest.java
@@ -1,5 +1,6 @@
 package fr.insalyon.creatis.vip.datamanager.server.business;
 
+import fr.insalyon.creatis.vip.core.client.view.CoreConstants;
 import fr.insalyon.creatis.vip.core.server.business.BusinessException;
 import fr.insalyon.creatis.vip.datamanager.client.bean.ExternalPlatform;
 import org.junit.jupiter.api.Assertions;
@@ -11,6 +12,7 @@ public class ShanoirStorageBusinessTest {
     public void testShanoirUri() throws BusinessException {
         ShanoirStorageBusiness shanoirStorageBusiness = new ShanoirStorageBusiness();
         ExternalPlatform externalPlatform = new ExternalPlatform();
+        externalPlatform.setIdentifier("testShanoir");
         externalPlatform.setType(ExternalPlatform.Type.SHANOIR);
         externalPlatform.setUrl("testShanoirUrl");
         externalPlatform.setRefreshTokenUrl("testRefreshTokenUrl");
@@ -37,6 +39,36 @@ public class ShanoirStorageBusinessTest {
                 "&amp;refreshToken=testRefreshToken";
 
         Assertions.assertEquals(expectedUri, uri);
+    }
 
+    @Test
+    public void testShanoirUploadUri() throws BusinessException {
+        ShanoirStorageBusiness shanoirStorageBusiness = new ShanoirStorageBusiness();
+        ExternalPlatform externalPlatform = new ExternalPlatform();
+        externalPlatform.setIdentifier("testShanoir");
+        externalPlatform.setType(ExternalPlatform.Type.SHANOIR);
+        externalPlatform.setUrl("testShanoirUrl");
+        externalPlatform.setRefreshTokenUrl("testRefreshTokenUrl");
+        externalPlatform.setUploadUrl("testUploadUrl");
+
+        String value = "testShanoir:/path/to/dir?" +
+                "type=File" +
+                "&md5=d41d8cd98f00b204e9800998ecf8427e" +
+                "&token=testToken" +
+                "&refreshToken=testRefreshToken" +
+                "&clientId=testKeycloakClientId";
+
+        String uploadUri = shanoirStorageBusiness.generateUri(externalPlatform, CoreConstants.RESULTS_DIRECTORY_PARAM_NAME, value);
+
+        String expectedUri="shanoir:/path/to/dir?" +
+                "upload_url=testUploadUrl" +
+                "&amp;type=File" +
+                "&amp;md5=d41d8cd98f00b204e9800998ecf8427e" +
+                "&amp;keycloak_client_id=testKeycloakClientId" +
+                "&amp;refresh_token_url=testRefreshTokenUrl" +
+                "&amp;token=testToken" +
+                "&amp;refreshToken=testRefreshToken";
+
+        Assertions.assertEquals(expectedUri, uploadUri);
     }
 }


### PR DESCRIPTION
This updates and replaces #530 :
- functionality should be identical
- add one extra test for upload URL generation
- change input URI parsing to use java.net.URI instead of regexps

Some implementation notes :
- input URI scheme and authority parts are not checked, but could be for extra-strictness. They've been noted in a comment.
- Spring UriComponentsBuilder is used for query string parsing. The only other place I found where we do that is in `ReproVipInputsParser.java`, which just does a `split("&")`.
- output URI generation is still based on strings concatenation. It would be a bit cleaner to use a proper URI object for that as well, but has some higher risk of changing behavior, especially with the `&amp;` escapes.
