### PR TITLE
zenodo improvement

### DIFF
--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/bean/PublicExecution.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/bean/PublicExecution.java
@@ -100,14 +100,16 @@ public class PublicExecution implements IsSerializable {
 
         for (String output : outputIds) {
             // splitting workflow-xxxxx-outname
-            startIndex = output.indexOf('-', 0) + 1;
-            workflowId = output.substring(0, output.indexOf('-', startIndex));
-            outputId = output.substring(output.indexOf('-', startIndex) + 1);
-
-            if (result.get(workflowId) != null) {
-                result.get(workflowId).add(outputId);
-            } else {
-                result.put(workflowId, new ArrayList<>(Arrays.asList(outputId)));
+            if ( ! output.isEmpty()) {
+                startIndex = output.indexOf('-', 0) + 1;
+                workflowId = output.substring(0, output.indexOf('-', startIndex));
+                outputId = output.substring(output.indexOf('-', startIndex) + 1);
+    
+                if (result.get(workflowId) != null) {
+                    result.get(workflowId).add(outputId);
+                } else {
+                    result.put(workflowId, new ArrayList<>(Arrays.asList(outputId)));
+                }
             }
         }
         return result;

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/reprovip/MakeExecutionPublicTab.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/reprovip/MakeExecutionPublicTab.java
@@ -161,10 +161,6 @@ public class MakeExecutionPublicTab extends Tab {
             SC.warn("The form is invalid");
             return false;
         }
-        if (getOutputIdsSelected().isEmpty()) {
-            SC.warn("Please select at least one output");
-            return false;
-        }
         if ( ! experienceNameField.getValueAsString().matches("[a-zA-Z0-9_-]+")) {
             SC.warn("Only alphanumerics characters and (-,_) are authorized!");
             return false;


### PR DESCRIPTION
Add the capability of not choosing outputs for an experience (only provenance and inputs will be specified)