### PR TITLE
Fix API file download

### DIFF
--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/DataApiBusiness.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/DataApiBusiness.java
@@ -281,7 +281,7 @@ public class DataApiBusiness {
             logger.error("Trying to download a non-existing file ({})", path);
             throw new ApiException("Illegal data API access");
         }
-        if (!type.get().equals(Data.Type.folder)) {
+        if (!type.get().equals(Data.Type.file)) {
             // it works on a directory and return a zip, but we cant check the download size
             logger.error("Trying to download a directory ({})", path);
             throw new ApiException("Illegal data API access");


### PR DESCRIPTION
Hotfix : `GET /rest/path/.../file?action=content` was broken in PR #524 due to a mixup in file/folder type test.
