### PR TITLE
fix privates autogroups

### DIFF
--- a/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/GroupBusiness.java
+++ b/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/business/GroupBusiness.java
@@ -134,7 +134,9 @@ public class GroupBusiness {
         if (group.isAuto()) {
             Group existing = getByType(group.getType()).stream().filter((g) -> g.isAuto()).findFirst().orElse(null);
 
-            if (existing != null) {
+            if ( ! group.isPublicGroup()) {
+                throw new BusinessException("You can only create public auto groups!");
+            } else if (existing != null && ! existing.getName().equals(group.getName())) {
                 throw new BusinessException("You can't have multiples auto groups of the same type!");
             }
         }

--- a/vip-core/src/test/java/fr/insalyon/creatis/vip/core/integrationtest/UsersAndGroupsIT.java
+++ b/vip-core/src/test/java/fr/insalyon/creatis/vip/core/integrationtest/UsersAndGroupsIT.java
@@ -122,9 +122,9 @@ public class UsersAndGroupsIT extends BaseSpringIT {
 
     @Test
     public void testThrowCreateExistingAutoGroup() throws BusinessException {
-        Group group = new Group("test_a", false, GroupType.APPLICATION, true);
-        Group groupBis = new Group("test_ab", false, GroupType.APPLICATION, true);
-        Group groupR = new Group("test_a_R", false, GroupType.RESOURCE, true);
+        Group group = new Group("test_a", true, GroupType.APPLICATION, true);
+        Group groupBis = new Group("test_ab", true, GroupType.APPLICATION, true);
+        Group groupR = new Group("test_a_R", true, GroupType.RESOURCE, true);
 
         groupBusiness.add(groupR);
         groupBusiness.add(group);


### PR DESCRIPTION
This pull request this an issue where an admin was able to create a private "auto" group.
An "auto" group can and MUST be only public.