### PR TITLE
Add source field in AppVersions

### DIFF
--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/bean/AppVersion.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/bean/AppVersion.java
@@ -53,33 +53,35 @@ public class AppVersion implements IsSerializable {
     private List<String> resources;
     private List<String> tags;
     private Map<String, String> settings;
+    private String source;
 
     public AppVersion() {}
 
     public AppVersion(String applicationName, String version, String descriptor,
-                      Map<String,String> settings, boolean visible) {
+                      Map<String,String> settings, boolean visible, String source) {
         this.applicationName = applicationName;
         this.version = version;
         this.descriptor = descriptor;
         this.visible = visible;
+        this.source = source;
         this.resources = new ArrayList<>();
         this.tags = new ArrayList<>();
         this.settings = settings;
     }
 
     public AppVersion(String applicationName, String version, String descriptor, boolean visible) {
-        this(applicationName, version, descriptor, new HashMap<>(), visible);
+        this(applicationName, version, descriptor, new HashMap<>(), visible, "");
     }
 
     public AppVersion(String applicationName, String version, String descriptor,
-                      String doi, Map<String,String> settings, boolean visible) {
-        this(applicationName, version, descriptor, settings, visible);
+                      String doi, Map<String,String> settings, boolean visible, String source) {
+        this(applicationName, version, descriptor, settings, visible, source);
         this.doi = doi;
     }
 
     public AppVersion(String applicationName, String version, String descriptor,
-                      String doi, boolean visible, List<String> resources, List<String> tags) {
-        this(applicationName, version, descriptor, visible);
+                      String doi, boolean visible, String source, List<String> resources, List<String> tags) {
+        this(applicationName, version, descriptor, new HashMap<>(), visible, source);
         this.doi = doi;
         this.resources = resources;
         this.tags = tags;
@@ -118,6 +120,10 @@ public class AppVersion implements IsSerializable {
 
     public boolean isVisible() {
         return visible;
+    }
+
+    public String getSource() {
+        return source;
     }
 
     public List<String> getResources() {

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/system/applications/app/ManageApplicationsTab.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/system/applications/app/ManageApplicationsTab.java
@@ -103,8 +103,8 @@ public class ManageApplicationsTab extends AbstractManageTab {
     }
 
     public void setVersion(String version, String descriptor, String doi, Map<String, String> settings,
-            boolean isVisible, String[] tags, String[] resources) {
-        editVersionLayout.setVersion(version, descriptor, isVisible, settings, tags, resources);
+            boolean isVisible, String source, String[] tags, String[] resources) {
+        editVersionLayout.setVersion(version, descriptor, isVisible, source, settings, tags, resources);
         manageVersionLayout.setVersion(version, descriptor, doi);
     }
 

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/system/applications/version/EditVersionLayout.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/system/applications/version/EditVersionLayout.java
@@ -238,7 +238,7 @@ public class EditVersionLayout extends AbstractFormLayout {
         } else {
             this.versionField.setValue("");
             this.versionField.setDisabled(false);
-            this.descriptorField.setValue("");
+            this.descriptorField.setValue("{}");
             this.descriptorField.setDisabled(true);
             this.isVisibleField.setValue(true);
             this.sourceField.setValue("");

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/system/applications/version/EditVersionLayout.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/system/applications/version/EditVersionLayout.java
@@ -72,6 +72,7 @@ public class EditVersionLayout extends AbstractFormLayout {
     private ListGrid settingsGrid;
     private IButton newSettingsButton;
     private CheckboxItem isVisibleField;
+    private TextItem sourceField;
     private SelectItem tagsList;
     private SelectItem resourcesList;
     private IButton saveButton;
@@ -118,6 +119,9 @@ public class EditVersionLayout extends AbstractFormLayout {
         isVisibleField.setWidth(450);
         isVisibleField.setValue(true);
 
+        sourceField = FieldUtil.getTextItem(450, null);
+        sourceField.setRequired(false);
+
         tagsList = new SelectItem();
         tagsList.setMultiple(true);
         tagsList.setWidth(450);
@@ -131,7 +135,8 @@ public class EditVersionLayout extends AbstractFormLayout {
             public void onClick(ClickEvent event) {
                 if (versionField.validate()) {
                     AppVersion toSave = new AppVersion(applicationName, versionField.getValueAsString().trim(),
-                            descriptorField.getValueAsString(), settingsToMap(), isVisibleField.getValueAsBoolean());
+                            descriptorField.getValueAsString(), settingsToMap(), isVisibleField.getValueAsBoolean(),
+                            sourceField.getValueAsString());
                     toSave.setResources(Arrays.asList(resourcesList.getValues()));
                     toSave.setTags(Arrays.asList(tagsList.getValues()));
                     save(toSave);
@@ -160,6 +165,7 @@ public class EditVersionLayout extends AbstractFormLayout {
         addField("Version", versionField);
         addField("Descriptor", descriptorField);
         addMember(FieldUtil.getForm(isVisibleField));
+        addField("Source", sourceField);
         addField("Tags associated", tagsList);
         addField("Resources authorized", resourcesList);
         addMember(WidgetUtil.getLabel("<b>" + "Execution Settings" + "</b>", 15));
@@ -198,7 +204,7 @@ public class EditVersionLayout extends AbstractFormLayout {
             public void onSuccess(Void result) {
                 WidgetUtil.resetIButton(saveButton, "Save", CoreConstants.ICON_SAVED);
                 WidgetUtil.resetIButton(removeButton, "Remove", CoreConstants.ICON_DELETE);
-                setVersion(null, null, true, null, null, null);
+                setVersion(null, null, true, null, null, null, null);
                 ManageApplicationsTab tab = (ManageApplicationsTab) Layout.getInstance().
                         getTab(ApplicationConstants.TAB_MANAGE_APPLICATION);
                 tab.loadVersions(applicationName);
@@ -207,7 +213,7 @@ public class EditVersionLayout extends AbstractFormLayout {
     }
 
     public void setApplication(String applicationName) {
-        setVersion(null, null, true, null, null, null);
+        setVersion(null, null, true, null, null, null, null);
         this.applicationName = applicationName;
         this.applicationLabel.setContents("<b>Application:</b> " + applicationName);
         this.versionField.setDisabled(false);
@@ -215,7 +221,7 @@ public class EditVersionLayout extends AbstractFormLayout {
         this.saveButton.setDisabled(false);
     }
 
-    public void setVersion(String version, String descriptor, boolean isVisible,
+    public void setVersion(String version, String descriptor, boolean isVisible, String source,
             Map<String, String> settings, String[] tags, String[] resources) {
         if (version != null) {
             this.versionField.setValue(version);
@@ -223,6 +229,7 @@ public class EditVersionLayout extends AbstractFormLayout {
             this.descriptorField.setValue(descriptor);
             this.descriptorField.setDisabled(true);
             this.isVisibleField.setValue(isVisible);
+            this.sourceField.setValue(source);
             this.tagsList.setValues(tags);
             this.resourcesList.setValues(resources);
             this.removeButton.setDisabled(false);
@@ -234,6 +241,7 @@ public class EditVersionLayout extends AbstractFormLayout {
             this.descriptorField.setValue("");
             this.descriptorField.setDisabled(true);
             this.isVisibleField.setValue(true);
+            this.sourceField.setValue("");
             this.removeButton.setDisabled(true);
             this.newVersion = true;
         }

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/system/applications/version/VersionRecord.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/system/applications/version/VersionRecord.java
@@ -43,11 +43,12 @@ import com.smartgwt.client.widgets.grid.ListGridRecord;
 public class VersionRecord extends ListGridRecord {
     
     public VersionRecord(String version, String descriptor, String doi, boolean isVisible,
-            Map<String, String> settings, List<String> tags, List<String> resources) {
+            String source, Map<String, String> settings, List<String> tags, List<String> resources) {
         setAttribute("version", version);
         setAttribute("descriptor", descriptor);
         setAttribute("doi", doi);
         setAttribute("visible", isVisible);
+        setAttribute("source", source);
         setAttribute("settings", settings);
         setAttribute("tags", tags);
         setAttribute("resources", resources);

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/system/applications/version/VersionsLayout.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/system/applications/version/VersionsLayout.java
@@ -101,7 +101,7 @@ public class VersionsLayout extends VLayout {
             public void onClick(ClickEvent event) {
                 ManageApplicationsTab appsTab = (ManageApplicationsTab) Layout.getInstance().
                         getTab(ApplicationConstants.TAB_MANAGE_APPLICATION);
-                appsTab.setVersion(null, null, null, null, true, null, null);
+                appsTab.setVersion(null, null, null, null, true, null, null, null);
             }
         });
         toolstrip.addMember(addButton);
@@ -204,7 +204,7 @@ public class VersionsLayout extends VLayout {
                 for (AppVersion version : result) {
                     dataList.add(new VersionRecord(
                         version.getVersion(), version.getDescriptor(),
-                        version.getDoi(), version.isVisible(),
+                        version.getDoi(), version.isVisible(), version.getSource(),
                         version.getSettings(), version.getTags(), version.getResources()));
                 }
                 grid.setData(dataList.toArray(new VersionRecord[]{}));
@@ -236,6 +236,7 @@ public class VersionsLayout extends VLayout {
             record.getAttribute("doi"),
             record.getAttributeAsMap("settings"),
             record.getAttributeAsBoolean("visible"),
+            record.getAttribute("source"),
             record.getAttributeAsStringArray("tags"),
             record.getAttributeAsStringArray("resources"));
     }

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/dao/mysql/ApplicationData.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/dao/mysql/ApplicationData.java
@@ -277,8 +277,8 @@ public class ApplicationData extends JdbcDaoSupport implements ApplicationDAO {
 
     @Override
     public void addVersion(AppVersion version) throws DAOException {
-        String query =  "INSERT INTO VIPAppVersions(application, version, descriptor, visible, settings) "
-        +               "VALUES (?, ?, ?, ?, ?)";
+        String query =  "INSERT INTO VIPAppVersions(application, version, descriptor, visible, settings, source) "
+        +               "VALUES (?, ?, ?, ?, ?, ?)";
 
         try (PreparedStatement ps = getConnection().prepareStatement(query)) {
             ps.setString(1, version.getApplicationName());
@@ -286,6 +286,7 @@ public class ApplicationData extends JdbcDaoSupport implements ApplicationDAO {
             ps.setString(3, version.getDescriptor());
             ps.setBoolean(4, version.isVisible());
             ps.setString(5, version.getSettingsAsString());
+            ps.setString(6, version.getSource());
             ps.executeUpdate();
 
         } catch (SQLException ex) {
@@ -302,15 +303,16 @@ public class ApplicationData extends JdbcDaoSupport implements ApplicationDAO {
 
     @Override
     public void updateVersion(AppVersion version) throws DAOException {
-        String query =  "UPDATE VIPAppVersions SET descriptor=?, visible=?, settings=? "
+        String query =  "UPDATE VIPAppVersions SET descriptor=?, visible=?, settings=?, source=? "
         +               "WHERE application=? AND version=?";
 
         try (PreparedStatement ps = getConnection().prepareStatement(query)) {
             ps.setString(1, version.getDescriptor());
             ps.setBoolean(2, version.isVisible());
             ps.setString(3, version.getSettingsAsString());
-            ps.setString(4, version.getApplicationName());
-            ps.setString(5, version.getVersion());
+            ps.setString(4, version.getSource());
+            ps.setString(5, version.getApplicationName());
+            ps.setString(6, version.getVersion());
             ps.executeUpdate();
 
         } catch (SQLException ex) {
@@ -423,7 +425,8 @@ public class ApplicationData extends JdbcDaoSupport implements ApplicationDAO {
             rs.getString("descriptor"),
             rs.getString("doi"),
             stringSettingsToMap(rs.getString("settings")),
-            rs.getBoolean("visible")
+            rs.getBoolean("visible"),
+            rs.getString("source")
         );
     }
 

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/dao/mysql/ApplicationDataInitializer.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/dao/mysql/ApplicationDataInitializer.java
@@ -116,6 +116,7 @@ public class ApplicationDataInitializer extends JdbcDaoSupport {
                 +   "doi VARCHAR(255), "
                 +   "settings TEXT, "
                 +   "visible BOOLEAN, "
+                +   "source TEXT, "
                 +   "PRIMARY KEY (application, version), "
                 +   "FOREIGN KEY (application) REFERENCES VIPApplications(name) "
                 +   "ON DELETE CASCADE ON UPDATE CASCADE");


### PR DESCRIPTION
This PR adds a new "source" field in AppVersions :
- this is a purely informative text field meant to document where the descriptor comes from.
- it is available for read/write in the web UI and the `/rest/admin` API. It is not interpreted for anything by VIP-portal.

Some points of attention :
- I used `TEXT` and not `VARCHAR(N)` as the SQL type, as URLs (a common value for this field) can be quite long.
- This PR also contains a very minor fix for the default value of the read-only descriptorField in EditVersionLayout.java, when adding a version manually from the web UI (an operation not done in practice)
- Impact on upcoming migrations :
  - schema change `ALTER TABLE VIPAppVersions ADD COLUMN source TEXT;` should be commented out in `migrate_db_*.sql` scripts whenever this PR is merged : see [here](https://github.com/virtual-imaging-platform/vip-scripts/blob/master/migration_v4/migrate_db_eskemm.sql#L56) and [there](https://github.com/virtual-imaging-platform/vip-scripts/blob/master/migration_v4/migrate_db_creatis.sql#L59)
  - a "source" column has been added to the CSV indexes that are planned for apps import. With a recent enough version of `vipapps.py sync_index`, this will set the source field to the content of that column. If the target instance of VIP-portal doesn't support the source field, then the column is just ignored.
