### PR TITLE
Fix "Save inputs", Allow app renaming with SQL

### DIFF
--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/dao/mysql/ApplicationDataInitializer.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/dao/mysql/ApplicationDataInitializer.java
@@ -125,7 +125,9 @@ public class ApplicationDataInitializer extends JdbcDaoSupport {
                     "application VARCHAR(255), "
                 +   "name VARCHAR(255), "
                 +   "inputs VARCHAR(32000), "
-                +   "PRIMARY KEY (application, name)");
+                +   "PRIMARY KEY (application, name),"
+                +   "FOREIGN KEY (application) REFERENCES VIPApplications(name) "
+                +   "ON DELETE CASCADE ON UPDATE CASCADE");
     }
 
     private void createTagsTables() {
@@ -152,6 +154,8 @@ public class ApplicationDataInitializer extends JdbcDaoSupport {
                 +   "inputs VARCHAR(32000), "
                 +   "PRIMARY KEY (email, application, name), "
                 +   "FOREIGN KEY (email) REFERENCES VIPUsers(email) "
+                +   "ON DELETE CASCADE ON UPDATE CASCADE,"
+                +   "FOREIGN KEY (application) REFERENCES VIPApplications(name) "
                 +   "ON DELETE CASCADE ON UPDATE CASCADE");
 
         tableInitializer.createTable("VIPPublicExecutions",

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/dao/mysql/ApplicationInputData.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/dao/mysql/ApplicationInputData.java
@@ -172,7 +172,7 @@ public class ApplicationInputData extends JdbcDaoSupport implements ApplicationI
 
     @Override
     public SimulationInput getInputByNameUserApp(String email, String name, String appName) throws DAOException {
-        String query =  "SELECT email, application, name, inputsFROM VIPAppInputs "
+        String query =  "SELECT email, application, name, inputs FROM VIPAppInputs "
         +               "WHERE email = ? AND name = ? AND application = ? "
         +               "ORDER BY name";
 


### PR DESCRIPTION
- Fix "Save inputs" feature currently broken in `develop` due to a syntax error in ApplicationInputData.java (since #514)
- Update `VIPAppExamples` and `VIPAppInputs` schema to declare the `application` field as a foreign key and cascade on application name change. This is also done in the upcoming migration script, see https://github.com/virtual-imaging-platform/vip-scripts/blob/master/migration_v4/migrate_db_creatis.sql#L117.
