### PR TITLE
Fix path transformation for local files

### DIFF
--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowBusiness.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowBusiness.java
@@ -276,7 +276,7 @@ public class WorkflowBusiness {
         if ( ! user.isSystemAdministrator()) {
             checkFolderACL(user, groups, parsedPath);
         }
-        return server.useLocalFilesInInputs() ? "file:" : "lfn:" + parsedPath;
+        return (server.useLocalFilesInInputs() ? "file:" : "lfn:") + parsedPath;
     }
 
     private boolean isAFileParameter(BoutiquesDescriptor boutiques, String parameterName) {


### PR DESCRIPTION
PR #563 path transformation in ` transformParameter()` was fine for `lfn:` paths, but broke all `file:` paths due to incorrect operator precedence.
