### PR TITLE
Add vip:overriddenInputs

### DIFF
--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/ExecutionBusiness.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/ExecutionBusiness.java
@@ -384,6 +384,20 @@ public class ExecutionBusiness {
                 throw new ApiException(ApiException.ApiError.INPUT_FIELD_MISSING, pp.getName());
             }
 
+            // fill in overriddenInputs from explicit inputs
+            Map<String, String> overriddenInputs = p.getOverriddenInputs();
+            if (overriddenInputs != null) {
+                for (String key : overriddenInputs.keySet()) {
+                    String value = overriddenInputs.get(key);
+                    if (inputValues.containsKey(value)) {
+                        inputValues.put(key, inputValues.get(value));
+                    } else {
+                        logger.error("Error initialising {}, missing {} parameter", pipelineId, value);
+                        throw new ApiException(ApiException.ApiError.INPUT_FIELD_MISSING, value);
+                    }
+                }
+            }
+
             boolean inputsContainsResultsDirectoryInput = inputValues.containsKey(CoreConstants.RESULTS_DIRECTORY_PARAM_NAME);
             boolean pipelineHasResultsDirectoryInput = p.getParameters().stream().anyMatch(param ->
                         param.getName().equals(CoreConstants.RESULTS_DIRECTORY_PARAM_NAME));

--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/PipelineBusiness.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/business/PipelineBusiness.java
@@ -57,6 +57,7 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import static fr.insalyon.creatis.vip.api.exception.ApiException.ApiError.*;
@@ -196,12 +197,20 @@ public class PipelineBusiness {
         Pipeline p = new Pipeline(pipelineId, boutiques.getName(), boutiques.getToolVersion());
         p.setDescription(boutiques.getDescription());
 
+        Map<String, String> overriddenInputs = boutiquesBusiness.getOverriddenInputs(boutiques);
         for (Input input : boutiques.getInputs()) {
+            if (overriddenInputs != null && overriddenInputs.containsKey(input.getId())) {
+                continue; // hide overriddenInputs from pipeline visible parameters
+            }
             ParameterType type = ParameterType.fromBoutiquesInput(input);
             PipelineParameter pp = new PipelineParameter(
                     input.getId(), type, input.getOptional() != null && input.getOptional(),false,
                     input.getDefaultValue(), input.getDescription());
             p.getParameters().add(pp);
+        }
+        // store overriddenInputs in pipeline object to avoid parsing the descriptor again later
+        if (overriddenInputs != null) {
+            p.setOverriddenInputs(overriddenInputs);
         }
         return p;
     }

--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/model/Pipeline.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/model/Pipeline.java
@@ -32,8 +32,10 @@
 package fr.insalyon.creatis.vip.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 /**
  *
@@ -47,6 +49,8 @@ public class Pipeline {
     private String version;
     private ArrayList<PipelineParameter> parameters;
     private boolean canExecute;
+    @JsonIgnore
+    private Map<String, String> overriddenInputs;
 
     public Pipeline() {
     }
@@ -86,5 +90,13 @@ public class Pipeline {
     @JsonProperty("canExecute") // jackson only take into account getter by default
     public boolean canExecute(){
         return canExecute;
+    }
+
+    public Map<String, String> getOverriddenInputs() {
+        return overriddenInputs;
+    }
+
+    public void setOverriddenInputs(Map<String, String> overriddenInputs) {
+        this.overriddenInputs = overriddenInputs;
     }
 }

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/bean/boutiquesTools/BoutiquesApplication.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/bean/boutiquesTools/BoutiquesApplication.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.user.client.rpc.IsSerializable;
 
 import fr.insalyon.creatis.vip.application.client.bean.boutiquesTools.BoutiquesInput.InputType;
@@ -42,6 +43,7 @@ public class BoutiquesApplication implements IsSerializable {
     private Map<String, String> tags = new HashMap<>();
     private Set<String> vipDotInputIds;
     private boolean vipDotIncludesResultsDir;
+    private Map<String, String> vipOverriddenInputs;
 
     private BoutiquesApplicationExtensions boutiquesExtensions;
 
@@ -228,6 +230,10 @@ public class BoutiquesApplication implements IsSerializable {
         return vipDotIncludesResultsDir;
     }
 
+    public Map<String, String> getVipOverriddenInputs() {
+        return vipOverriddenInputs;
+    }
+
     public void addInput(BoutiquesInput input){
         this.inputs.add(input);
     }
@@ -282,5 +288,9 @@ public class BoutiquesApplication implements IsSerializable {
 
     public void setVipDotIncludesResultsDir(boolean vipDotIncludesResultsDir) {
         this.vipDotIncludesResultsDir = vipDotIncludesResultsDir;
+    }
+
+    public void setVipOverriddenInputs(Map<String, String> vipOverriddenInputs) {
+        this.vipOverriddenInputs = vipOverriddenInputs;
     }
 }

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/boutiquesParsing/BoutiquesParser.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/boutiquesParsing/BoutiquesParser.java
@@ -1,5 +1,6 @@
 package fr.insalyon.creatis.vip.application.client.view.boutiquesParsing;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -105,6 +106,15 @@ public class BoutiquesParser extends AbstractJsonParser {
             application.setVipContainer(getStringValue(customObject, "vip:imagepath", true));
             application.setVipDotInputIds(getArrayValueAsStringSet(customObject, "vip:dot", true));
             application.setVipDotIncludesResultsDir(getBooleanValue(customObject, "vip:dot-with-results-directory", true));
+            JSONObject vipOverriddenInputs = getObjectValue(customObject, "vip:overriddenInputs", true);
+            if (vipOverriddenInputs != null) {
+                Map<String, String> overriddenInputs = new HashMap<>();
+                for (String key: vipOverriddenInputs.keySet()) {
+                    String value = getStringValue(vipOverriddenInputs, key);
+                    overriddenInputs.put(key, value);
+                }
+                application.setVipOverriddenInputs(overriddenInputs);
+            }
         }
         return application;
     }

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/launch/LaunchFormLayout.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/launch/LaunchFormLayout.java
@@ -315,7 +315,11 @@ public class LaunchFormLayout extends AbstractFormLayout {
                 .filter(i -> i.isOptional()).collect(Collectors.toSet());
 
 
+        Map<String, String> overriddenInputs = applicationDescriptor.getVipOverriddenInputs();
         for (BoutiquesInput input : mandatoryInputs) {
+            if (overriddenInputs != null && overriddenInputs.containsKey(input.getId())) {
+                continue; // do not put overridden inputs in the form, they'll be filled in server-side
+            }
             configureInput(applicationDescriptor, input);
         }
         if (optionalInputs.isEmpty()) {

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/launch/LaunchTab.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/launch/LaunchTab.java
@@ -154,6 +154,14 @@ public class LaunchTab extends Tab {
             public void onSuccess(String boutiquesDescriptorString) {
                 try {
                     BoutiquesApplication applicationTool = new BoutiquesParser().parseApplication(boutiquesDescriptorString);
+                    Map<String, String> overriddenInputs = applicationTool.getVipOverriddenInputs();
+                    // when we have both predefined inputs (i.e. on relaunch) and overriddenInputs,
+                    // remove overriddenInputs from the inputs map, so that it matches the form content
+                    if (inputs != null && overriddenInputs != null) {
+                        for (String key: overriddenInputs.keySet()) {
+                            inputs.remove(key);
+                        }
+                    }
                     addExtensionAndCreateForm(applicationTool, true, () -> createForm(applicationTool));
                 } catch (InvalidBoutiquesDescriptorException exception) {
                     Layout.getInstance().setWarningMessage("Unable to parse application descriptor:<br />"

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/BoutiquesBusiness.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/BoutiquesBusiness.java
@@ -34,6 +34,7 @@ package fr.insalyon.creatis.vip.application.server.business;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import fr.insalyon.creatis.boutiques.model.BoutiquesDescriptor;
+import fr.insalyon.creatis.boutiques.model.Custom;
 import fr.insalyon.creatis.vip.application.client.bean.AppVersion;
 import fr.insalyon.creatis.vip.core.client.bean.User;
 import fr.insalyon.creatis.vip.core.server.business.BusinessException;
@@ -50,7 +51,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by abonnet on 2/21/19.
@@ -256,5 +259,28 @@ public class BoutiquesBusiness {
                 logger.error("Error closing {}", c);
             }
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, String> getOverriddenInputs(BoutiquesDescriptor descriptor) {
+        final String customKeyName = "vip:overriddenInputs";
+        Custom custom = descriptor.getCustom();
+        if (custom == null) {
+            return null;
+        }
+        Map<String, Object> customProperties = custom.getAdditionalProperties();
+        if (!customProperties.containsKey(customKeyName)) {
+            return null;
+        }
+        Map<String, String> result = new HashMap<String, String>();
+        Object overriddenInputs = customProperties.get(customKeyName);
+        if (overriddenInputs instanceof Map) {
+            Map<String, String> oi = (Map<String,String>)overriddenInputs;
+            for (String key: oi.keySet()) {
+                String value = oi.get(key);
+                result.put(key, value);
+            }
+        }
+        return result;
     }
 }

--- a/vip-gatelab/src/main/java/fr/insalyon/creatis/vip/gatelab/client/view/launch/GateLabLaunchTab.java
+++ b/vip-gatelab/src/main/java/fr/insalyon/creatis/vip/gatelab/client/view/launch/GateLabLaunchTab.java
@@ -63,7 +63,6 @@ public class GateLabLaunchTab extends LaunchTab {
 
     public static final String GATE_INPUT_ID = "gateInput";
     public static final String NB_JOBS_INPUT_ID = "numberOfJobs";
-    public static final String JOB_NUMBER_INPUT_ID = "jobNumber";
     public static final String MACFILE_INPUT_ID = "macfileName";
 
     public GateLabLaunchTab(String applicationName, String applicationVersion, String applicationClass) {
@@ -110,7 +109,7 @@ public class GateLabLaunchTab extends LaunchTab {
         applicationTool.setBoutiquesExtensions(extensions);
 
         extensions.addNonListInputs(
-                GATE_INPUT_ID, NB_JOBS_INPUT_ID, JOB_NUMBER_INPUT_ID, MACFILE_INPUT_ID);
+                GATE_INPUT_ID, NB_JOBS_INPUT_ID, MACFILE_INPUT_ID);
         enrichNumberOfJobsInput(applicationTool, extensions);
         launchFormCreator.run();
     }
@@ -118,7 +117,6 @@ public class GateLabLaunchTab extends LaunchTab {
     private void verifyBoutiquesDescriptor(BoutiquesApplication applicationTool) {
         verifyBoutiquesInput(applicationTool, GATE_INPUT_ID, BoutiquesInput.InputType.FILE);
         verifyBoutiquesInput(applicationTool, NB_JOBS_INPUT_ID, BoutiquesInput.InputType.NUMBER);
-        verifyBoutiquesInput(applicationTool, JOB_NUMBER_INPUT_ID, BoutiquesInput.InputType.NUMBER);
         verifyBoutiquesInput(applicationTool, MACFILE_INPUT_ID, BoutiquesInput.InputType.STRING);
     }
 
@@ -196,8 +194,6 @@ public class GateLabLaunchTab extends LaunchTab {
 
             String[] keyAndValue = inputs[1].split(" = ");
             valuesMap.put(keyAndValue[0], keyAndValue[1]);
-
-            valuesMap.put(JOB_NUMBER_INPUT_ID,"1");
 
             super.createButtons(); // override "load mac button" with "launch button"
             launchFormLayout.showInputs();

--- a/vip-gatelab/src/main/java/fr/insalyon/creatis/vip/gatelab/client/view/launch/GateLabLaunchTab.java
+++ b/vip-gatelab/src/main/java/fr/insalyon/creatis/vip/gatelab/client/view/launch/GateLabLaunchTab.java
@@ -59,15 +59,12 @@ public class GateLabLaunchTab extends LaunchTab {
 
     private LoadMacWindow loadMacWindow;
     private String baseDir;
-    private String releaseDir;
     private IButton loadMacButton;
 
-    public static final String GATE_RELEASE_INPUT_ID = "GateRelease";
-    public static final String CPU_ESTIMATION_INPUT_ID = "CPUestimation";
-    public static final String PARALLELIZATION_TYPE_INPUT_ID = "ParallelizationType";
-    public static final String GATE_INPUT_INPUT_ID = "GateInput";
-    public static final String NB_OF_PARTICLES_INPUT_ID = "NumberOfParticles";
-    public static final String PHASE_SPACE_INPUT_ID = "phaseSpace";
+    public static final String GATE_INPUT_ID = "gateInput";
+    public static final String NB_JOBS_INPUT_ID = "numberOfJobs";
+    public static final String JOB_NUMBER_INPUT_ID = "jobNumber";
+    public static final String MACFILE_INPUT_ID = "macfileName";
 
     public GateLabLaunchTab(String applicationName, String applicationVersion, String applicationClass) {
         super(applicationName, applicationVersion, applicationClass);
@@ -82,7 +79,6 @@ public class GateLabLaunchTab extends LaunchTab {
     protected void init() {
         super.init();
         baseDir = DataManagerConstants.ROOT + "/Home/myGateSimus/inputs";
-        releaseDir = "/vip/GateLab (group)/releases/";
         this.showExamples = false;
         this.showSeparators = false;
 
@@ -110,25 +106,20 @@ public class GateLabLaunchTab extends LaunchTab {
     protected void addExtensionAndCreateForm(
             BoutiquesApplication applicationTool, Boolean addResultsDirectoryInput, Runnable launchFormCreator) {
         verifyBoutiquesDescriptor(applicationTool);
-        BoutiquesApplicationExtensions extensions = new BoutiquesApplicationExtensions(false);
+        BoutiquesApplicationExtensions extensions = new BoutiquesApplicationExtensions(true);
         applicationTool.setBoutiquesExtensions(extensions);
 
         extensions.addNonListInputs(
-                GATE_RELEASE_INPUT_ID, CPU_ESTIMATION_INPUT_ID, PARALLELIZATION_TYPE_INPUT_ID,
-                GATE_INPUT_INPUT_ID, NB_OF_PARTICLES_INPUT_ID, PHASE_SPACE_INPUT_ID);
-        enrichCPUEstimationInput(applicationTool, extensions);
-        enrichParallelizationType(applicationTool, extensions);
-        // do the asynchronous task last for clarity
-        enrichGateReleasesInput(applicationTool, extensions, launchFormCreator);
+                GATE_INPUT_ID, NB_JOBS_INPUT_ID, JOB_NUMBER_INPUT_ID, MACFILE_INPUT_ID);
+        enrichNumberOfJobsInput(applicationTool, extensions);
+        launchFormCreator.run();
     }
 
     private void verifyBoutiquesDescriptor(BoutiquesApplication applicationTool) {
-        verifyBoutiquesInput(applicationTool, GATE_RELEASE_INPUT_ID, BoutiquesInput.InputType.STRING);
-        verifyBoutiquesInput(applicationTool, CPU_ESTIMATION_INPUT_ID, BoutiquesInput.InputType.NUMBER);
-        verifyBoutiquesInput(applicationTool, PARALLELIZATION_TYPE_INPUT_ID, BoutiquesInput.InputType.STRING);
-        verifyBoutiquesInput(applicationTool, GATE_INPUT_INPUT_ID, BoutiquesInput.InputType.FILE);
-        verifyBoutiquesInput(applicationTool, NB_OF_PARTICLES_INPUT_ID, BoutiquesInput.InputType.NUMBER);
-        verifyBoutiquesInput(applicationTool, PHASE_SPACE_INPUT_ID, BoutiquesInput.InputType.STRING);
+        verifyBoutiquesInput(applicationTool, GATE_INPUT_ID, BoutiquesInput.InputType.FILE);
+        verifyBoutiquesInput(applicationTool, NB_JOBS_INPUT_ID, BoutiquesInput.InputType.NUMBER);
+        verifyBoutiquesInput(applicationTool, JOB_NUMBER_INPUT_ID, BoutiquesInput.InputType.NUMBER);
+        verifyBoutiquesInput(applicationTool, MACFILE_INPUT_ID, BoutiquesInput.InputType.STRING);
     }
 
     private void verifyBoutiquesInput(BoutiquesApplication applicationTool, String inputId, BoutiquesInput.InputType type) {
@@ -141,76 +132,22 @@ public class GateLabLaunchTab extends LaunchTab {
                 "Input {" + inputId + "} must have a number type in Gate descriptor");
     }
 
-    private void enrichCPUEstimationInput(
+    private void enrichNumberOfJobsInput(
             BoutiquesApplication applicationTool, BoutiquesApplicationExtensions extensions) {
-        BoutiquesInput cpuEstInput = applicationTool.getInputs().stream()
-                .filter(input -> CPU_ESTIMATION_INPUT_ID.equals(input.getId()))
+        BoutiquesInput numberOfJobs = applicationTool.getInputs().stream()
+                .filter(input -> NB_JOBS_INPUT_ID.equals(input.getId()))
                 .findAny().orElseThrow(IllegalStateException::new);
         Map<String, String> map = new LinkedHashMap<String, String>();
-        map.put("1", "A few minutes");
-        map.put("2", "A few hours");
-        map.put("3", "A few days");
-        map.put("4", "More than a few days");
+        map.put("1", "Short simulation of few minutes");
+        map.put("10", "Simulation of few hours");
+        map.put("100", "Simulation of a few days");
+        map.put("500", "Simulation of more than a few days");
         LaunchFormLayout.assertCondition(
-                cpuEstInput.getPossibleValues() != null && cpuEstInput.getPossibleValues().equals(map.keySet()),
-                "CPU Estimation in Gate descriptor does not have the expected values");
-        extensions.addValueChoiceLabels(CPU_ESTIMATION_INPUT_ID, map);
+                numberOfJobs.getPossibleValues() != null && numberOfJobs.getPossibleValues().equals(map.keySet()),
+                "Number of jobs in Gate descriptor does not have the expected values");
+        extensions.addValueChoiceLabels(NB_JOBS_INPUT_ID, map);
     }
 
-    private void enrichParallelizationType(
-            BoutiquesApplication applicationTool, BoutiquesApplicationExtensions extensions) {
-        BoutiquesInput paraTypeInput = applicationTool.getInputs().stream()
-                .filter(input -> PARALLELIZATION_TYPE_INPUT_ID.equals(input.getId()))
-                .findAny().orElseThrow(IllegalStateException::new);
-        Map<String, String> map = new LinkedHashMap<String, String>();
-        map.put("stat", "Static");
-        map.put("dyn", "Dynamic");
-        LaunchFormLayout.assertCondition(
-                paraTypeInput.getPossibleValues() != null && paraTypeInput.getPossibleValues().equals(map.keySet()),
-                "CPU Estimation in Gate descriptor does not have the expected values");
-        extensions.addValueChoiceLabels(PARALLELIZATION_TYPE_INPUT_ID, map);
-    }
-
-    private void enrichGateReleasesInput(
-            BoutiquesApplication applicationTool, BoutiquesApplicationExtensions extensions, Runnable doNextStep) {
-        BoutiquesInput releaseInput = applicationTool.getInputs().stream()
-                .filter(input -> GATE_RELEASE_INPUT_ID.equals(input.getId()))
-                .findAny().orElseThrow(IllegalStateException::new);
-        //get list of available releases
-        DataManagerServiceAsync service = DataManagerService.Util.getInstance();
-        AsyncCallback<List<Data>> callback = new AsyncCallback<List<Data>>() {
-            @Override
-            public void onFailure(Throwable caught) {
-                modal.hide();
-                Layout.getInstance().setWarningMessage("Unable to list release folder:<br />" + caught.getMessage());
-            }
-
-            @Override
-            public void onSuccess(List<Data> result) {
-                modal.hide();
-                List<Release> releases = new ArrayList<Release>();
-                for (Data d : result) {
-                    releases.add(new Release(d.getName()));
-                }
-                Collections.sort(releases);
-                updateGateReleaseInput(releaseInput, extensions, releases);
-                doNextStep.run();;
-            }
-        };
-        service.listDir(releaseDir, true, callback);
-    }
-
-    private void updateGateReleaseInput(
-            BoutiquesInput releaseInput, BoutiquesApplicationExtensions extensions, List<Release> releases) {
-        Map<String, String> releaseMap = new LinkedHashMap<String, String>();
-        String defaultValue = releaseDir + "/" + releases.get(0).getReleaseName();
-        for (Release r : releases) {
-            releaseMap.put(releaseDir + "/" + r.getReleaseName(), r.getReleaseName());
-        }
-        releaseInput.setPossibleValues(releaseMap.keySet());
-        ((BoutiquesStringInput) releaseInput).setDefaultValue(defaultValue);
-        extensions.addValueChoiceLabels(releaseInput.getId(), releaseMap);
-    }
 
     @Override
     protected void onLaunchFormCreated() {
@@ -227,7 +164,7 @@ public class GateLabLaunchTab extends LaunchTab {
     protected void onLaunchFormReady() {
         super.onLaunchFormReady();
         if (this.inputs != null) {
-            customizeGateForm(this.inputs.get(PARALLELIZATION_TYPE_INPUT_ID));
+            customizeGateForm();
         }
     }
 
@@ -249,7 +186,7 @@ public class GateLabLaunchTab extends LaunchTab {
             loadMacWindow = null;
 
             modal.hide();
-            // we get something like "GateInput = " + fileName + ", ParallelizationType = " + type + ", NumberOfParticles = " + parts + ", phaseSpace = " + ps;
+            // we get something like "gateInput = " + fileName + ", macfileName = " + mainMacFileName;
             String[] inputs = inputList.split(", ");
             Map<String,String> valuesMap = new HashMap<>();
 
@@ -257,29 +194,23 @@ public class GateLabLaunchTab extends LaunchTab {
             String[] it = inputs[0].split(" = ");
             valuesMap.put(it[0], baseDir.concat("/").concat(it[1]));
 
-            for (int i=1 ; i<4 ; i++) {
-                String[] keyAndValue = inputs[i].split(" = ");
-                valuesMap.put(keyAndValue[0], keyAndValue[1]);
-            }
-            valuesMap.put(CPU_ESTIMATION_INPUT_ID,"1");
+            String[] keyAndValue = inputs[1].split(" = ");
+            valuesMap.put(keyAndValue[0], keyAndValue[1]);
+
+            valuesMap.put(JOB_NUMBER_INPUT_ID,"1");
 
             super.createButtons(); // override "load mac button" with "launch button"
             launchFormLayout.showInputs();
             launchFormLayout.enableErrorsAndWarnings();
             launchFormLayout.loadInputs(launchFormLayout.getSimulationName(), valuesMap, false);
 
-            customizeGateForm(valuesMap.get(PARALLELIZATION_TYPE_INPUT_ID));
+            customizeGateForm();
         }
     }
 
-    public void customizeGateForm(String parallelizationType) {
+    public void customizeGateForm() {
         // hide and disable some inputs
-            launchFormLayout.hideInput(PHASE_SPACE_INPUT_ID);
-            launchFormLayout.makeInputUnmodifiable(GATE_INPUT_INPUT_ID);
-            launchFormLayout.makeInputUnmodifiable(NB_OF_PARTICLES_INPUT_ID);
-            if ("stat".equals(parallelizationType)) {
-                launchFormLayout.makeInputUnmodifiable(PARALLELIZATION_TYPE_INPUT_ID);
-            }
+            launchFormLayout.makeInputUnmodifiable(GATE_INPUT_ID);
     }
 
     // called from JS

--- a/vip-gatelab/src/main/java/fr/insalyon/creatis/vip/gatelab/server/business/GateLabInputs.java
+++ b/vip-gatelab/src/main/java/fr/insalyon/creatis/vip/gatelab/server/business/GateLabInputs.java
@@ -105,12 +105,10 @@ public class GateLabInputs {
 
         String gateInput = inputsMap.get("gateInput");
         String numberOfJobs = inputsMap.get("numberOfJobs");
-        String jobNumber = inputsMap.get("jobNumber");
         String macfileName = inputsMap.get("macfileName");
         Map<String, String> inputMap = new HashMap<String, String>();
         inputMap.put("gateInput", gateInput);
         inputMap.put("numberOfJobs", numberOfJobs);
-        inputMap.put("jobNumber", jobNumber);
         inputMap.put("macfileName", macfileName);
 
         return inputMap;

--- a/vip-gatelab/src/main/java/fr/insalyon/creatis/vip/gatelab/server/business/GateLabInputs.java
+++ b/vip-gatelab/src/main/java/fr/insalyon/creatis/vip/gatelab/server/business/GateLabInputs.java
@@ -103,49 +103,17 @@ public class GateLabInputs {
     public Map<String, String> getWorkflowInputs(String currentUserFolder)
             throws BusinessException {
 
-        try {
-            String input = inputsMap.get("GateInput");
-            /*
-             * int ind = input.lastIndexOf("/"); String inputlink =
-             * input.substring(0, ind);
-             *
-             * String application_name = "unknown";
-             *
-             * if (input.indexOf(".zip") > 0) { application_name =
-             * input.substring(ind + 1, input.indexOf(".zip"));
-             *
-             * } else if (input.indexOf(".tgz") > 0) { application_name =
-             * input.substring(ind + 1, input.indexOf(".tgz"));
-             *
-             * } else if (input.indexOf(".tar.gz") > 0) { application_name =
-             * input.substring(ind + 1, input.indexOf(".tar.gz"));
-             *
-             * } else if (input.indexOf(".zip") > 0) { application_name =
-             * input.substring(ind + 1, input.indexOf(".zip")); }
-             *
-             * String outputlink = inputlink + "/output";
-             */
-            String release = inputsMap.get("GateRelease");
-            String particles = inputsMap.get("NumberOfParticles");
-            String simtype = inputsMap.get("ParallelizationType").equals("dyn") ?
-                    "Dynamic" : "Static";
-            String phaseSpace = inputsMap.get("phaseSpace");
-            Map<String, String> inputMap = new HashMap<String, String>();
-            inputMap.put(
-                "inputlink",
-                    lfcPathsBusiness.parseRealDir(input, currentUserFolder));
-            //inputMap.put("outputlink", DataManagerUtil.parseRealDir(outputlink));
-            inputMap.put(
-                "gate_version",
-                    lfcPathsBusiness.parseRealDir(release, currentUserFolder));
-            inputMap.put("particles", particles);
-            inputMap.put("simulation", simtype);
-            inputMap.put("phaseSpace", phaseSpace);
+        String gateInput = inputsMap.get("gateInput");
+        String numberOfJobs = inputsMap.get("numberOfJobs");
+        String jobNumber = inputsMap.get("jobNumber");
+        String macfileName = inputsMap.get("macfileName");
+        Map<String, String> inputMap = new HashMap<String, String>();
+        inputMap.put("gateInput", gateInput);
+        inputMap.put("numberOfJobs", numberOfJobs);
+        inputMap.put("jobNumber", jobNumber);
+        inputMap.put("macfileName", macfileName);
 
-            return inputMap;
+        return inputMap;
 
-        } catch (DataManagerException ex) {
-            throw new BusinessException(ex);
-        }
     }
 }

--- a/vip-portal/src/main/webapp/js/macroParser.js
+++ b/vip-portal/src/main/webapp/js/macroParser.js
@@ -198,39 +198,17 @@ function getListOfFiles(dataArray, parentFolderId) {
         alert(e.toString() + " This shouldn't be an issue for Gate version inferior to 9.2. Please add this file to your data folder for Gate 9.2 and above.");
     }
 
-
-    //Add Wfl config file containing the name of the main Mac file. 
-    //Note that the created file has a name and a content, but no path
-    var mainMacFileName = dataArray.macFilesArray[0];
-    var configFile = new File([mainMacFileName], "wfl_config.txt", {type: "text/plain"});
-    myListOfFiles.push(configFile);
-
     return myListOfFiles;
 }
 
-function isSimuStatic(dataArray) {
-    if (dataArray.timeSimu === "timeSimu") {
-        return true;
-    }
-    return false;
-}
 function fillInInputs(fileName, dataArray) {
-    //var type = isSimuStatic(dataArray) ? "stat" : "dyn";
-    //force static simulation while waiting for confirmation of dynamic mode removal
-    var type = "stat";
-    //TODO handle phaseSpace use-case
-    var ps = "dummy";
-    var parts = dataArray.totalNumberOfPrimaries;
-    if (parts === "") {
-        parts = "100";
-    }
     if (dataArray.engineSeed !== "auto") {
         throw "SetEngineSeed is not auto. Please set the auto engine seed mode.";
     }
     if (dataArray.visu === "visu") {
         throw "Vizualisation found in the GATE macro files. Please remove any vis commands and start again.";
     }
-    var inputsList = "GateInput = " + fileName + ", ParallelizationType = " + type + ", NumberOfParticles = " + parts + ", phaseSpace = " + ps;
+    var inputsList = "gateInput = " + fileName + ", macfileName = " + dataArray.macFilesArray[0];
     return inputsList;
 }
 


### PR DESCRIPTION
This adds the `vip:overriddenInputs` custom property :
- see doc in the [wiki](https://github.com/virtual-imaging-platform/VIP-portal/wiki/Advanced-boutiques-descriptors#custom-properties)
- used in the [GATE-9.4.1.json](https://github.com/virtual-imaging-platform/vip-apps-boutiques-descriptors/blob/main/GATE/GATE-9.4.1.json) descriptor

It is based on PR [#562](https://github.com/virtual-imaging-platform/VIP-portal/pull/562), which should be merged first.
- Most of the patch is independent from GATE : https://github.com/virtual-imaging-platform/VIP-portal/compare/develop...f919e9fdb1a173ddd977d9eb928e8845c2b2790e contains the `vip:overriddenInputs` patch per se, which should work for any app. The intent is to support the new property while keeping the diff small enough for a short-term merge, so there is some minor redundancy between API and UI logic, and a new server-side parse of the descriptor in `WorkflowServiceImpl.java:launchSimulation()` for parameter injection on UI launch. I reused places with existing descriptor parsing for all the other cases : parameter hiding (in UI form, on relaunch, and `GET /rest/pipeline/<id>` API); and parameter injection on API launch.

- On top of that, I just mergedPR [#562](https://github.com/virtual-imaging-platform/VIP-portal/pull/562), and added the extra commit https://github.com/virtual-imaging-platform/VIP-portal/commit/7bd6cb7a1feb6a4c1e14e3823cb84d8cbfc9d62f to remove the now hidden `jobNumber` field from GATE UI.
