### PR TITLE
Update application import : add warnings, adjust checks

### DIFF
--- a/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/GeneralLayout.java
+++ b/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/GeneralLayout.java
@@ -44,7 +44,6 @@ public class GeneralLayout extends AbstractFormLayout {
             dockerImage,
             version,
             description,
-            vipContainer,
             dotInputs;
 
     public GeneralLayout(String width, String height) {
@@ -59,10 +58,9 @@ public class GeneralLayout extends AbstractFormLayout {
         dockerImage = new LocalTextField("Docker Image", false, false);
         version = new LocalTextField("Version", false, false);
         description = new LocalTextField("Description", false, false);
-        vipContainer = new LocalTextField("VIP Container", false, false);
         dotInputs = new LocalTextField("DOT Inputs", false, false);
 
-        this.addMembers(name, version, description, commandLine, dockerImage, vipContainer, dotInputs);
+        this.addMembers(name, version, description, commandLine, dockerImage, dotInputs);
     }
 
     public void setTool(BoutiquesApplication bt) {
@@ -71,8 +69,6 @@ public class GeneralLayout extends AbstractFormLayout {
         description.setValue(bt.getDescription());
         commandLine.setValue(bt.getCommandLine());
         dockerImage.setValue(bt.getContainerImage());
-        vipContainer.setValue(bt.getVipContainer());
-        String dotInputsValue = String.join(", ", bt.getVipDotInputIds());
-        dotInputs.setValue(dotInputsValue + (bt.getVipDotIncludesResultsDir() ? (dotInputsValue.isEmpty() ? "results-directory" : ", results-directory") : ""));
+        dotInputs.setValue(String.join(", ", bt.getVipDotInputIds()));
     }
 }

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/bean/boutiquesTools/BoutiquesApplication.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/bean/boutiquesTools/BoutiquesApplication.java
@@ -38,11 +38,9 @@ public class BoutiquesApplication implements IsSerializable {
     private String schemaVersion;
     private String challengerEmail;
     private String challengerTeam;
-    private String vipContainer;
     private Set<BoutiquesOutputFile> outputFiles = new HashSet<>();
     private Map<String, String> tags = new HashMap<>();
     private Set<String> vipDotInputIds;
-    private boolean vipDotIncludesResultsDir;
     private Map<String, String> vipOverriddenInputs;
 
     private BoutiquesApplicationExtensions boutiquesExtensions;
@@ -202,10 +200,6 @@ public class BoutiquesApplication implements IsSerializable {
         return tags;
     }
 
-    public String getVipContainer() {
-        return vipContainer;
-    }
-
     public Set<String> getVipDotInputIds() {
         if (vipDotInputIds == null) {
             return Collections.emptySet();      
@@ -224,10 +218,6 @@ public class BoutiquesApplication implements IsSerializable {
         return this.getInputs().stream()
                 .map(BoutiquesInput::getId)
                 .collect(Collectors.toSet());
-    }
-
-    public boolean getVipDotIncludesResultsDir() {
-        return vipDotIncludesResultsDir;
     }
 
     public Map<String, String> getVipOverriddenInputs() {
@@ -278,16 +268,8 @@ public class BoutiquesApplication implements IsSerializable {
         tags.put(key, value);
     }
 
-    public void setVipContainer(String vipContainer) {
-        this.vipContainer = vipContainer;
-    }
-
     public void setVipDotInputIds(Set<String> inputIds) {
         this.vipDotInputIds = inputIds;
-    }
-
-    public void setVipDotIncludesResultsDir(boolean vipDotIncludesResultsDir) {
-        this.vipDotIncludesResultsDir = vipDotIncludesResultsDir;
     }
 
     public void setVipOverriddenInputs(Map<String, String> vipOverriddenInputs) {

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/boutiquesParsing/BoutiquesParser.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/boutiquesParsing/BoutiquesParser.java
@@ -103,9 +103,7 @@ public class BoutiquesParser extends AbstractJsonParser {
         // Custom property
         JSONObject customObject = getObjectValue(parsedDescriptor, "custom", true);
         if (customObject != null) {
-            application.setVipContainer(getStringValue(customObject, "vip:imagepath", true));
             application.setVipDotInputIds(getArrayValueAsStringSet(customObject, "vip:dot", true));
-            application.setVipDotIncludesResultsDir(getBooleanValue(customObject, "vip:dot-with-results-directory", true));
             JSONObject vipOverriddenInputs = getObjectValue(customObject, "vip:overriddenInputs", true);
             if (vipOverriddenInputs != null) {
                 Map<String, String> overriddenInputs = new HashMap<>();


### PR DESCRIPTION
- Add consistency checks for name and version strings, and warnings on container-image field, to match the error and warning controls done in [vipapps.py](https://github.com/virtual-imaging-platform/VIP-python-client/blob/develop/vipapps/vipapps.py). - Remove "vip:imagepath" from import preview
- Remove unused "vip:dot-with-results-directory" from BoutiquesParser.java
