### PR TITLE
Update GET /rest/pipelines?public

### DIFF
--- a/vip-api/src/main/java/fr/insalyon/creatis/vip/api/controller/processing/PipelineController.java
+++ b/vip-api/src/main/java/fr/insalyon/creatis/vip/api/controller/processing/PipelineController.java
@@ -74,13 +74,9 @@ public class PipelineController extends ApiController {
     }
 
     @RequestMapping(params = "public")
-    public List<Application> listPublicPipelines() throws ApiException {
+    public List<Pipeline> listPublicPipelines() throws ApiException {
         logMethodInvocation(logger, "listPublicPipelines");
-        List<Application> pipelines = pipelineBusiness.listPublicPipelines();
-        for (Application application : pipelines) {
-            application.removeOwner();
-        }
-        return pipelines;
+        return pipelineBusiness.listPublicPipelines();
     }
 
     @RequestMapping("{pipelineId}")

--- a/vip-portal/src/main/webapp/js/sign-in.js
+++ b/vip-portal/src/main/webapp/js/sign-in.js
@@ -172,10 +172,10 @@ async function get_fetch(form_email, form_password){
 }
 
 function make_table(data) {
+    var pipelineNames = data[0].map((item) => item.name); // list of public pipelines names
+    pipelineNames = [...new Set(pipelineNames)]; // remove duplicates
     var application = new Array();
-    data[0].forEach((item, index) => {
-        application.push([index, item.name])
-    });
+    pipelineNames.forEach((name, index) => { application.push([index, name])});
 
     let tablecontents = createTableHTMLString(application);
     document.getElementById("my_tbody_app").innerHTML = tablecontents;


### PR DESCRIPTION
- Change `GET /rest/pipelines?public` to return a payload of pipeline objects instead of application objects. This API call now returns the same CARMIN-compliant structure as `GET /rest/pipelines`, for AppVersions belonging to a public group.
- Update login page UI in sign-in.js to remove duplicate names before rendering. The resulting UI is unchanged.
