### PR TITLE
Fix app import exception with no container-image

### DIFF
--- a/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/DisplayTab.java
+++ b/vip-application-importer/src/main/java/fr/insalyon/creatis/vip/applicationimporter/client/view/applicationdisplay/DisplayTab.java
@@ -216,6 +216,7 @@ public class DisplayTab extends Tab {
         String containerImage = application.getContainerImage();
         if (containerImage == null) {
             warnings.add("No container-image");
+            return;
         }
         String containerIndex = application.getContainerIndex();
         if (containerIndex != null && containerIndex != "docker://") {


### PR DESCRIPTION
Fix a regression introduced in https://github.com/virtual-imaging-platform/VIP-portal/pull/577 when importing a descriptor with no `container-image` section.
