### PR TITLE
resources fix

### DIFF
--- a/vip-api/src/test/java/fr/insalyon/creatis/vip/api/rest/itest/processing/ExecutionControllerIT.java
+++ b/vip-api/src/test/java/fr/insalyon/creatis/vip/api/rest/itest/processing/ExecutionControllerIT.java
@@ -395,7 +395,7 @@ public class ExecutionControllerIT extends BaseWebSpringIT {
 
         Mockito.when(server.getVoName()).thenReturn("test-vo-name");
         Mockito.when(server.getServerProxy("test-vo-name")).thenReturn("/path/to/proxy");
-        Mockito.when(getWebServiceEngine().launch(eq(engineEndpoint), workflowContentCaptor.capture(), inputsCaptor.capture(), eq("{}"), eq(""), eq("/path/to/proxy"))).thenReturn(workflowId, (String) null);
+        Mockito.when(getWebServiceEngine().launch(eq(engineEndpoint), workflowContentCaptor.capture(), inputsCaptor.capture(), eq("{\"default.executor\":\"LOCAL\"}"), eq(""), eq("/path/to/proxy"))).thenReturn(workflowId, (String) null);
         Mockito.when(getWebServiceEngine().getStatus(engineEndpoint, workflowId)).thenReturn(SimulationStatus.Running, (SimulationStatus) null);
 
         Workflow w = new Workflow(workflowId, baseUser1.getFullName(), WorkflowStatus.Running, startDate, null, "Exec test 1", appName, versionName, "", engineEndpoint, null);
@@ -451,7 +451,7 @@ public class ExecutionControllerIT extends BaseWebSpringIT {
         Resource resource = new Resource(
             "testResource", 
             true, 
-            ResourceType.BATCH, 
+            ResourceType.LOCAL, 
             "", 
             Arrays.asList(engine.getName()),
             Arrays.asList(new Group("testResources", true, GroupType.APPLICATION)));

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/ApplicationConstants.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/ApplicationConstants.java
@@ -133,6 +133,7 @@ public class ApplicationConstants {
     public static final String SEPARATOR_LIST = "@@";
     public static final String INPUT_VALID_CHARS = "0-9.,A-Za-z-+@/_(): ";
     public static final String EXEC_NAME_VALID_CHARS = "0-9A-Za-z-_ ";
+    public static final String DEFAULT_EXECUTOR_GASW = "default.executor";
 
     public static String getLaunchTabID(String applicationName) {
         return "launch_"

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/system/resources/EditResourceLayout.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/system/resources/EditResourceLayout.java
@@ -59,7 +59,7 @@ public class EditResourceLayout extends AbstractFormLayout {
 
         nameField = FieldUtil.getTextItem(350, null);
         configurationField = FieldUtil.getTextItem(350, null);
-        configurationField.setRequired(false);
+        configurationField.setRequired(true);
 
         statusField = new BooleanItem();
         statusField.setShowTitle(false);
@@ -90,7 +90,7 @@ public class EditResourceLayout extends AbstractFormLayout {
                         List<String> groupsNames = Arrays.asList(groupsList.getValues());
                         List<Group> groups = groupsNames.stream()
                             .map((name) -> new Group(groupsMap.get(name), false, GroupType.RESOURCE)).collect(Collectors.toList());
-                        if (nameField.validate()) {
+                        if (nameField.validate() && configurationField.validate()) {
                             save(new Resource(
                                 nameField.getValueAsString().trim(),
                                 statusField.getValueAsBoolean(),
@@ -122,7 +122,7 @@ public class EditResourceLayout extends AbstractFormLayout {
         addField("Name", nameField);
         addField("Active", statusField);
         addField("Type", typeFieldList);
-        addField("Configuration", configurationField);
+        addField("Configuration Folder", configurationField);
         addField("Engines", enginesList);
         addField("Groups Resources", groupsList);
         addButtons(saveButton, removeButton);

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/system/resources/ResourceLayout.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/system/resources/ResourceLayout.java
@@ -137,7 +137,7 @@ public class ResourceLayout extends VLayout {
                 new ListGridField("name", "Name"),
                 new ListGridField("status", "Active"),
                 new ListGridField("type", "Type"),
-                new ListGridField("configuration", "Configuration"),
+                new ListGridField("configuration", "Configuration Folder"),
                 new ListGridField("engines", "Engines"),
                 new ListGridField("groupsLabel", "Groups Resources"));
         grid.setSortField("name");

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowBusiness.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowBusiness.java
@@ -168,9 +168,9 @@ public class WorkflowBusiness {
             Resource resource = resources.get(0);
             Engine engine = engineBusiness.selectEngine(engineBusiness.getUsableEngines(resource));
 
+            appVersion.getSettings().put(ApplicationConstants.DEFAULT_EXECUTOR_GASW, resource.getType().toString());
             try {
-                workflow = workflowExecutionBusiness.launch(engine.getEndpoint(), appVersion, user, simulationName, parameters,
-                    resource.getType().toString(), resource.getConfiguration());
+                workflow = workflowExecutionBusiness.launch(engine.getEndpoint(), appVersion, user, simulationName, parameters, resource.getConfiguration());
             } catch (BusinessException be) {
                 logger.error("BusinessException caught on launch workflow, engine {} will be disabled", engine.getName());
             } catch (Exception e) {

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowExecutionBusiness.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowExecutionBusiness.java
@@ -69,13 +69,14 @@ public class WorkflowExecutionBusiness {
     }
 
     public Workflow launch(String engineEndpoint, AppVersion appVersion, User user, String simulationName,
-            List<ParameterSweep> parameters, String settings, String executorConfig) throws BusinessException {
+            List<ParameterSweep> parameters, String executorConfig) throws BusinessException {
 
         try {
             String workflowContent = appVersion.getDescriptor();
             String inputs = (parameters != null) ? getParametersAsXMLInput(parameters) : null;
             String proxyFileName = server.getServerProxy(server.getVoName());
             String settingsJSON = new ObjectMapper().writeValueAsString(appVersion.getSettings());
+            System.err.println(settingsJSON);
             String workflowID = engine.launch(engineEndpoint, workflowContent, inputs, settingsJSON, executorConfig, proxyFileName);
             return new Workflow(workflowID, user.getFullName(),
                     WorkflowStatus.Running, new Date(), null, simulationName, 

--- a/vip-local/src/main/java/fr/insalyon/creatis/vip/local/LocalWorkflowExecutionBusiness.java
+++ b/vip-local/src/main/java/fr/insalyon/creatis/vip/local/LocalWorkflowExecutionBusiness.java
@@ -36,7 +36,7 @@ public class LocalWorkflowExecutionBusiness extends WorkflowExecutionBusiness {
 
     @Override
     public Workflow launch(String engineEndpoint, AppVersion appVersion, User user, String simulationName,
-            List<ParameterSweep> parameters, String settings, String executorConfig) throws BusinessException {
+            List<ParameterSweep> parameters, String executorConfig) throws BusinessException {
         String workflowContent;
         try {
             workflowContent = appVersion.getDescriptor();


### PR DESCRIPTION
With this PR the `default.executor` is already pre-defined by the type of resource that you'll use.
The resource configuration field is more restrictive and precise: can't be empty and represent the path to the configuration folder of the resource.