### PR TITLE
avoid deactivate on non critical engine errors

### DIFF
--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/ApplicationError.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/ApplicationError.java
@@ -6,7 +6,8 @@ public enum ApplicationError implements VipError {
 
     PLATFORM_MAX_EXECS(2000, "Max number of running executions reached on the platform.", 0),
     USER_MAX_EXECS(2001, "Max number of running executions reached.<br />You already have {} running executions.", 1),
-    WRONG_APPLICATION_DESCRIPTOR(2002, "Error getting application descriptor for {}.", 1);
+    WRONG_APPLICATION_DESCRIPTOR(2002, "Error getting application descriptor for {}.", 1),
+    ENGINE_SATURATED(2003, "Engine is saturated!", 0);
 
     private final String message;
     private final Integer code;
@@ -25,4 +26,3 @@ public enum ApplicationError implements VipError {
     @Override public Integer getExpectedParameters() { return expectedParams; }
     @Override public Integer getHttpCode() { return httpCode; }
 }
-

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/ApplicationError.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/client/view/ApplicationError.java
@@ -7,7 +7,8 @@ public enum ApplicationError implements VipError {
     PLATFORM_MAX_EXECS(2000, "Max number of running executions reached on the platform.", 0),
     USER_MAX_EXECS(2001, "Max number of running executions reached.<br />You already have {} running executions.", 1),
     WRONG_APPLICATION_DESCRIPTOR(2002, "Error getting application descriptor for {}.", 1),
-    ENGINE_SATURATED(2003, "Engine is saturated!", 0);
+    ENGINE_SATURATED(2003, "Engine is saturated!", 0),
+    LAUNCH_ERROR(2004, "Error launching execution, contact admins!", 0);
 
     private final String message;
     private final Integer code;

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowBusiness.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowBusiness.java
@@ -161,26 +161,28 @@ public class WorkflowBusiness {
             try {
                 workflow = workflowExecutionBusiness.launch(engine.getEndpoint(), appVersion, user, simulationName, parameters, resource.getConfiguration());
             } catch (Exception e) {
-                // no code mean not intended exception = engine deactivation
+                String mailSubject = "[VIP] Warn: Workflow submission failed!!";
+                String mailContent = "An error occured while submitting a workflow";
+                Exception exceptionToRethrow = e;
+
                 if (e instanceof VipException vipEx && vipEx.getVipErrorCode().isEmpty()) {
+                    // intended errors, only warning by mail
+                    logger.warn("Error occuring during workflow submission. Not disabling, sending mail to admins");
+                } else {
+                    if ( ! (e instanceof VipException)) {
+                        logger.error("Unexpected exception while launching a workflow", e);
+                        exceptionToRethrow = new VipException(ApplicationError.LAUNCH_ERROR, e);
+                    }
+                    logger.warn(
+                            "Error occuring during workflow submission. Disabling engine and sending mail to admins");
+                    mailSubject = "[VIP] Urgent: VIP engine disabled !";
+                    mailContent = "Engine " + engine.getName() + " has just been disabled.";
                     engine.setStatus("disabled");
                     engineBusiness.update(engine);
-
-                    logger.info("Sending warning email to admins !");
-                    emailBusiness.sendEmailToAdmins(
-                        "Urgent: VIP engine disabled", 
-                        "Engine " + engine.getName() + " has just been disabled. Please check that there is at least one active engine left.", 
-                        true, user.getEmail());
-                } else {
-                    logger.warn("Error occuring during workflow submission!");
-
-                    emailBusiness.sendEmailToAdmins(
-                        "Warn: Workflow submission failed!", 
-                        "An error occured while submitting a workflow: " + e.getMessage() + "\nStacktrace: " + e.getStackTrace(), 
-                        true, user.getEmail());
                 }
-
-                throw e;
+                mailContent += "\n\nException:" + e.getMessage() + "\nStacktrace: " + e.getStackTrace();
+                emailBusiness.sendEmailToAdmins(mailSubject, mailContent, true, user.getEmail());
+                throw (VipException) exceptionToRethrow;
             }
             logger.info("Launched workflow " + workflow.toString());
 

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowBusiness.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowBusiness.java
@@ -160,11 +160,9 @@ public class WorkflowBusiness {
             appVersion.getSettings().put(ApplicationConstants.DEFAULT_EXECUTOR_GASW, resource.getType().toString());
             try {
                 workflow = workflowExecutionBusiness.launch(engine.getEndpoint(), appVersion, user, simulationName, parameters, resource.getConfiguration());
-            } catch (VipException e) {
+            } catch (Exception e) {
                 // no code mean not intended exception = engine deactivation
-                if (e.getVipErrorCode().isEmpty()) {
-                    logger.error("Unexpected exception caught on launch workflow, engine {} will be disabled", engine.getName(), e);
-
+                if (e instanceof VipException vipEx && vipEx.getVipErrorCode().isEmpty()) {
                     engine.setStatus("disabled");
                     engineBusiness.update(engine);
 

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowBusiness.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowBusiness.java
@@ -160,25 +160,22 @@ public class WorkflowBusiness {
             appVersion.getSettings().put(ApplicationConstants.DEFAULT_EXECUTOR_GASW, resource.getType().toString());
             try {
                 workflow = workflowExecutionBusiness.launch(engine.getEndpoint(), appVersion, user, simulationName, parameters, resource.getConfiguration());
-            } catch (VipException be) {
-                logger.error("VipException caught on launch workflow, engine {} will be disabled", engine.getName());
+            } catch (VipException e) {
+                throw e;
             } catch (Exception e) {
                 logger.error("Unexpected exception caught on launch workflow, engine {} will be disabled", engine.getName(), e);
-            } finally {
-                if (workflow == null) {
-                    engine.setStatus("disabled");
-                    engineBusiness.update(engine);
 
-                    logger.info("Sending warning email to admins !");
-                    emailBusiness.sendEmailToAdmins(
-                        "Urgent: VIP engine disabled", 
-                        "Engine " + engine.getName() + " has just been disabled. Please check that there is at least one active engine left.", 
-                        true, user.getEmail());
-                    throw new VipException("Workflow is null, engine " + engine.getName() + " has been disabled");
-                } else {
-                    logger.info("Launched workflow " + workflow.toString());
-                }
+                engine.setStatus("disabled");
+                engineBusiness.update(engine);
+
+                logger.info("Sending warning email to admins !");
+                emailBusiness.sendEmailToAdmins(
+                    "Urgent: VIP engine disabled", 
+                    "Engine " + engine.getName() + " has just been disabled. Please check that there is at least one active engine left.", 
+                    true, user.getEmail());
+                throw new VipException("Failed to launch workflow! Engine " + engine.getName() + " has been disabled");
             }
+            logger.info("Launched workflow " + workflow.toString());
 
             workflowDAO.add(workflow);
             return workflow.getId();

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowExecutionBusiness.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowExecutionBusiness.java
@@ -37,7 +37,7 @@ public class WorkflowExecutionBusiness {
     }
 
     public Workflow launch(String engineEndpoint, AppVersion appVersion, User user, String simulationName,
-            Map<String, List<String>> parameters, String executorConfig) throws VipException, Exception {
+            Map<String, List<String>> parameters, String executorConfig) throws VipException {
 
         try {
             String workflowContent = appVersion.getDescriptor();

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowExecutionBusiness.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/WorkflowExecutionBusiness.java
@@ -1,11 +1,8 @@
 package fr.insalyon.creatis.vip.application.server.business;
 
-import java.rmi.RemoteException;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-
-import javax.xml.rpc.ServiceException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,20 +37,21 @@ public class WorkflowExecutionBusiness {
     }
 
     public Workflow launch(String engineEndpoint, AppVersion appVersion, User user, String simulationName,
-            Map<String, List<String>> parameters, String executorConfig) throws VipException {
+            Map<String, List<String>> parameters, String executorConfig) throws VipException, Exception {
 
         try {
             String workflowContent = appVersion.getDescriptor();
             String inputs = (parameters != null) ? getParametersAsJSONInput(parameters) : null;
             String proxyFileName = server.getServerProxy(server.getVoName());
             String settingsJSON = new ObjectMapper().writeValueAsString(appVersion.getSettings());
-            String workflowID = engine.launch(engineEndpoint, workflowContent, inputs, settingsJSON, executorConfig, proxyFileName);
-            return new Workflow(workflowID, user.getFullName(),
-                    WorkflowStatus.Running, new Date(), null, simulationName, 
+            String id = engine.launch(engineEndpoint, workflowContent, inputs, settingsJSON, executorConfig, proxyFileName);
+
+            return new Workflow(id, user.getFullName(),
+                    WorkflowStatus.Running, new Date(), null, simulationName,
                     appVersion.getApplicationName(), appVersion.getVersion(), "",
                     engineEndpoint, null);
 
-        } catch (ServiceException | RemoteException | JsonProcessingException ex) {
+        } catch (JsonProcessingException ex) {
             logger.error("Error launching simulation {} ({}/{})",
                     simulationName, appVersion.getApplicationName(), appVersion.getVersion(), ex);
             throw new VipException(ex);
@@ -61,24 +59,11 @@ public class WorkflowExecutionBusiness {
     }
 
     public SimulationStatus getStatus(String engineEndpoint, String simulationID) throws VipException {
-        SimulationStatus status = SimulationStatus.Unknown;
-        try {
-            status = engine.getStatus(engineEndpoint, simulationID);
-        } catch (RemoteException | ServiceException e) {
-            logger.error("Error getting status of simulation {} on engine {}", simulationID, engineEndpoint, e);
-            throw new VipException(e);
-        }
-
-        return status;
+        return engine.getStatus(engineEndpoint, simulationID);
     }
 
     public void kill(String engineEndpoint, String simulationID) throws VipException {
-        try {
-            engine.kill(engineEndpoint, simulationID);
-        } catch (RemoteException | ServiceException e) {
-            logger.error("Error killing simulation {} on engine {}", simulationID, engineEndpoint, e);
-            throw new VipException(e);
-        }
+        engine.kill(engineEndpoint, simulationID);
     }
 
     public String getParametersAsJSONInput(Map<String, List<String>> parameters) throws VipException {

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/simulation/RestServiceEngine.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/simulation/RestServiceEngine.java
@@ -113,14 +113,14 @@ public class RestServiceEngine extends WorkflowEngineInstantiator {
                     throw new VipException(ApplicationError.ENGINE_SATURATED, e);
                 case 400:
                     logger.warn("Application likely misconfigured: {}", e.getMessage(), e);
-                    throw new VipException(DefaultError.GENERIC_ERROR, e);
+                    throw new VipException(ApplicationError.LAUNCH_ERROR, e);
                 default:
                     logger.error("Server error while fetching workflow status: {}", e.getResponseBodyAsString(), e);
                     throw new VipException("Internal server error while fetching workflow status", e);
             }
         } catch (RestClientException e) {
-            logger.error("REST client error while fetching workflow status", e);
-            throw new VipException("REST client error while fetching workflow status", e);
+            logger.error("REST error launching execution", e);
+            throw new VipException("REST error launching execution", e);
         }
     }
 

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/simulation/RestServiceEngine.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/simulation/RestServiceEngine.java
@@ -88,17 +88,16 @@ public class RestServiceEngine extends WorkflowEngineInstantiator {
 
         RestWorkflow restWorkflow = new RestWorkflow(base64Workflow, base64Input, base64Proxy, base64Settings, base64ExecutorConfig);
 
+        ObjectMapper mapper = new ObjectMapper();
+        String jsonBody;
+
         try {
-            ObjectMapper mapper = new ObjectMapper();
-            String jsonBody;
-
-            try {
-                jsonBody = mapper.writeValueAsString(restWorkflow);
-            } catch (JsonProcessingException e) {
-                logger.error("Error serializing RestWorkflow to JSON", e);
-                throw new VipException("Error serializing RestWorkflow to JSON", e);
-            }
-
+            jsonBody = mapper.writeValueAsString(restWorkflow);
+        } catch (JsonProcessingException e) {
+            logger.error("Error serializing RestWorkflow to JSON", e);
+            throw new VipException("Error serializing RestWorkflow to JSON", e);
+        }
+        try {
             RestClient restClient = buildRestClient(addressWS);
             return restClient.post()
                     .uri("/submit")

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/simulation/WorkflowEngineInstantiator.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/simulation/WorkflowEngineInstantiator.java
@@ -13,17 +13,13 @@ public abstract class WorkflowEngineInstantiator {
     }
 
     public abstract String launch(String addressWS, String workflowContent, String inputs, String settings, String executorConfig, String proxyFileName)
-            throws java.rmi.RemoteException, javax.xml.rpc.ServiceException, VipException;
+            throws VipException, Exception;
 
     public abstract void kill(String addressWS, String workflowID)
-            throws
-            java.rmi.RemoteException,
-            javax.xml.rpc.ServiceException, VipException;
+            throws VipException;
 
     public abstract SimulationStatus getStatus(String addressWS, String workflowID)
-            throws
-            java.rmi.RemoteException,
-            javax.xml.rpc.ServiceException, VipException;
+            throws VipException;
 
     protected void loadTrustStore(Server server) {
         // Configuration SSL

--- a/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/simulation/WorkflowEngineInstantiator.java
+++ b/vip-application/src/main/java/fr/insalyon/creatis/vip/application/server/business/simulation/WorkflowEngineInstantiator.java
@@ -13,7 +13,7 @@ public abstract class WorkflowEngineInstantiator {
     }
 
     public abstract String launch(String addressWS, String workflowContent, String inputs, String settings, String executorConfig, String proxyFileName)
-            throws VipException, Exception;
+            throws VipException;
 
     public abstract void kill(String addressWS, String workflowID)
             throws VipException;


### PR DESCRIPTION
This pull request is related to this [one on moteur-server-rest](https://github.com/virtual-imaging-platform/moteur-server-rest/pull/15).

The changes are related to the way we deactivate engine on errors. It was too strict..

Now only system errors (_Exception_) will trigger the deactivation of the engine. 
For the others ones (__BusinessException__) a message will be displayed and the workflow won't start.
