### PR TITLE
update h2 from 1.x to 2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
         <springsecurity.version>6.3.4</springsecurity.version>
         <springoauth.version>6.3.4</springoauth.version>
         <jackson.version>2.18.0</jackson.version>
-        <h2database.version>1.4.196</h2database.version>
+        <h2database.version>2.4.240</h2database.version>
     </properties>
 
     <description>VIP</description>

--- a/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/dao/mysql/CoreDataInitializer.java
+++ b/vip-core/src/main/java/fr/insalyon/creatis/vip/core/server/dao/mysql/CoreDataInitializer.java
@@ -71,15 +71,15 @@ public class CoreDataInitializer extends JdbcDaoSupport {
                         + "last_login TIMESTAMP, "
                         + "level VARCHAR(50), "
                         + "country_code VARCHAR(2), "
-                        + "max_simulations int(11), "
+                        + "max_simulations INT, "
                         + "termsUse TIMESTAMP, "
                         + "lastUpdatePublications TIMESTAMP,"
-                        + "failed_authentications int(11),"
+                        + "failed_authentications INT,"
                         + "account_locked BOOLEAN,"
                         + "apikey VARCHAR(255),"
                         + "PRIMARY KEY(email),"
-                        + "UNIQUE KEY(first_name,last_name),"
-                        + "UNIQUE KEY(apikey)")) {
+                        + "UNIQUE (first_name,last_name),"
+                        + "UNIQUE (apikey)")) {
 
             String folder = server.getAdminFirstName().toLowerCase() + "_"
                     + server.getAdminLastName().toLowerCase();
@@ -125,7 +125,7 @@ public class CoreDataInitializer extends JdbcDaoSupport {
 
     private void initializeTermsOfUseTable() {
         if (tableInitializer.createTable("VIPTermsOfUse",
-                "id INT(11) NOT NULL AUTO_INCREMENT, "
+                "id INT NOT NULL AUTO_INCREMENT, "
                         + "date TIMESTAMP NULL, "
                         + "PRIMARY KEY (id)")) {
             try {

--- a/vip-core/src/test/java/fr/insalyon/creatis/vip/core/integrationtest/UsersAndGroupsIT.java
+++ b/vip-core/src/test/java/fr/insalyon/creatis/vip/core/integrationtest/UsersAndGroupsIT.java
@@ -229,7 +229,7 @@ public class UsersAndGroupsIT extends BaseSpringIT {
                         configurationBusiness.addUserToGroup("nonExistent user", nameGroup1)
         );
         // INSERT + nonExistent foreign key / part of primary key groupName => user email
-        assertTrue(StringUtils.contains(exception.getMessage(), "JdbcSQLException: Referential integrity constraint violation"));
+        assertTrue(StringUtils.contains(exception.getMessage(), "Referential integrity constraint violation"));
     }
 
     @Test
@@ -241,7 +241,7 @@ public class UsersAndGroupsIT extends BaseSpringIT {
                 );
 
         // INSERT + nonExistent foreign key / part of primary key groupName => violation
-        assertTrue(StringUtils.contains(exception.getMessage(), "JdbcSQLException: Referential integrity constraint violation"));
+        assertTrue(StringUtils.contains(exception.getMessage(), "Referential integrity constraint violation"));
 
     }
 

--- a/vip-publication/src/main/java/fr/insalyon/creatis/vip/publication/server/dao/PublicationDataInitializer.java
+++ b/vip-publication/src/main/java/fr/insalyon/creatis/vip/publication/server/dao/PublicationDataInitializer.java
@@ -70,7 +70,7 @@ public class PublicationDataInitializer extends JdbcDaoSupport {
 
         tableInitializer.createTable(
                 "VIPPublications",
-                "id INT(11) NOT NULL AUTO_INCREMENT, "
+                "id INT NOT NULL AUTO_INCREMENT, "
                         + "title text, "
                         + "date VARCHAR(45), "
                         + "doi VARCHAR(255), "

--- a/vip-publication/src/test/java/fr/insalyon/creatis/vip/publication/integrationtest/PublicationsIT.java
+++ b/vip-publication/src/test/java/fr/insalyon/creatis/vip/publication/integrationtest/PublicationsIT.java
@@ -100,7 +100,7 @@ public class PublicationsIT extends BaseSpringIT {
         );
 
         // INSERT + nonExistent foreign key vipAuthor => violation
-        assertTrue(StringUtils.contains(exception.getMessage(), "JdbcSQLException: Referential integrity constraint violation"));
+        assertTrue(StringUtils.contains(exception.getMessage(), "Referential integrity constraint violation"));
     }
 
 
@@ -167,7 +167,7 @@ public class PublicationsIT extends BaseSpringIT {
         );
 
         // UPDATE + nonExistent foreign key vipAuthor => violation
-        assertTrue(StringUtils.contains(exception.getMessage(), "JdbcSQLException: Referential integrity constraint violation"));
+        assertTrue(StringUtils.contains(exception.getMessage(), "Referential integrity constraint violation"));
         // Verify the update didn't take place
         assertEquals(adminEmail, publicationBusiness.getPublication(idPublicationCreated).getVipAuthor(), "Incorrect vipAuthor publication updated");
     }

--- a/vip-social/src/test/java/fr/insalyon/creatis/vip/social/integrationtest/SocialIT.java
+++ b/vip-social/src/test/java/fr/insalyon/creatis/vip/social/integrationtest/SocialIT.java
@@ -171,7 +171,7 @@ public class SocialIT extends BaseSpringIT {
         );
 
         // INSERT + nonExistent foreign key sender => violation
-        assertTrue(StringUtils.contains(exception.getMessage(), "JdbcSQLException: Referential integrity constraint violation"));
+        assertTrue(StringUtils.contains(exception.getMessage(), "Referential integrity constraint violation"));
     }
 
 
@@ -561,7 +561,7 @@ public class SocialIT extends BaseSpringIT {
                 );
 
         // INSERT + nonExistent foreign key sender => violation
-        assertTrue(StringUtils.contains(exception.getMessage(), "JdbcSQLException: Referential integrity constraint violation"));
+        assertTrue(StringUtils.contains(exception.getMessage(), "Referential integrity constraint violation"));
     }
 
 
@@ -580,7 +580,7 @@ public class SocialIT extends BaseSpringIT {
                 );
 
         // INSERT + nonExistent foreign key groupName => violation
-        assertTrue(StringUtils.contains(exception.getMessage(), "JdbcSQLException: Referential integrity constraint violation"));
+        assertTrue(StringUtils.contains(exception.getMessage(), "Referential integrity constraint violation"));
     }
 
     @Test


### PR DESCRIPTION
### What's new!

This Pull Request is related with : [vip-workflow-engine](https://github.com/virtual-imaging-platform/vip-workflow-engine/pull/40), [GASW-H2-Plugin](https://github.com/virtual-imaging-platform/GASW-H2-Plugin/pull/7).
By migrating from H2 1.x to 2.x we have to make some changes.

Indeed the **SQL parser** of 2.x version is stricter than before!

- *UNIQUE KEY* **is changed** to *UNIQUE*: this is the same and MariaDB have an alias but not H2 ([see](https://stackoverflow.com/questions/9201584/what-is-the-difference-between-unique-unique-key-and-constraint-name-unique))
- *INT(x)* is **no longer supported**. I suggest to remove it to *INT*. In fact the behavior of "x" was only for displaying and not really limiting the integer size in database, then in our case I don't think it will change something. ([see](https://stackoverflow.com/questions/5634104/what-is-the-size-of-column-of-int11-in-mysql-in-bytes), [see](https://dev.mysql.com/doc/refman/8.4/en/integer-types.html))

Also the class for `Referential integrity constraint violation` exception is no longer `JdbcSQLException`. I've adapted the tests consequently.

> [!NOTE]
> I don't think we need a db migration script for that, but it might be good to make a small check.