### PR TITLE
warning fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,11 @@ knowledge of the CeCILL-B license and that you accept its terms.
                     </execution>
                 </executions>
             </plugin>
+            <!-- 
+            Starting from Java 21, JDK restrict abilites of librairies to perform actions inside the JVM.
+            That's why you need to explicitly declare them as `javaagent`.
+            ref: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3
+            -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -284,13 +284,30 @@ knowledge of the CeCILL-B license and that you accept its terms.
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>3.5.4</version>
+                <configuration>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.5.4</version>
+                <configuration>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/vip-portal/pom.xml
+++ b/vip-portal/pom.xml
@@ -211,7 +211,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
         </dependency>
 
         <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-dev</artifactId>
             <scope>provided</scope>
             <exclusions>


### PR DESCRIPTION
I've updated the pom as described in mockito [documentation](https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3)
Also removed the warning due to GWT-dev package relocation.